### PR TITLE
Show main form stats and email link

### DIFF
--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -54,6 +54,7 @@
             <RadzenPanelMenuItem Text="Home" Path="" Icon="Home"/>
             <RadzenPanelMenuItem Text="Create Form" Path="forms/new" Icon="add_box" />
             <RadzenPanelMenuItem Text="My Forms" Path="myforms" Icon="list" />
+            <RadzenPanelMenuItem Text="Search Forms" Path="forms/search" Icon="search" />
         </RadzenPanelMenu>
 
         <!-- Footer section of the sidebar -->

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -1,6 +1,8 @@
 ﻿@page "/razer"
 @using System.Net.Http.Json
 @using System.Text.Json
+@using DynamicFormsApp.Shared.Models
+@inject IUserService UserService
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
@@ -19,6 +21,17 @@
     <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" />
     <label class="form-check-label" for="loginToggle">Require login to access form</label>
 </div>
+<div class="form-check form-switch mb-4">
+    <input class="form-check-input" type="checkbox" id="notifyToggle" @bind="notifyOnResponse" />
+    <label class="form-check-label" for="notifyToggle">Email on new response</label>
+</div>
+@if (notifyOnResponse)
+{
+    <div class="mb-3">
+        <label class="form-label">Notification Email</label>
+        <input class="form-control" placeholder="@currentUser?.Email" @bind="notificationEmail" />
+    </div>
+}
 
 @foreach (var field in fields)
 {
@@ -87,6 +100,9 @@
     private string formName = string.Empty;
     private List<DesignerField> fields = new();
     private bool requireLogin = true;
+    private bool notifyOnResponse = false;
+    private string notificationEmail = string.Empty;
+    private UserModel? currentUser;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -97,6 +113,11 @@
             {
                 var ret = Uri.EscapeDataString(Navigation.ToBaseRelativePath(Navigation.Uri));
                 Navigation.NavigateTo($"login?returnUrl={ret}", true);
+            }
+            else
+            {
+                currentUser = await UserService.GetUserData(user);
+                notificationEmail = currentUser?.Email ?? string.Empty;
             }
         }
     }
@@ -119,6 +140,9 @@
         {
             Name = formName,
             RequireLogin = requireLogin,
+            NotifyOnResponse = notifyOnResponse,
+            NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
+            IsActive = true,
             Fields = fields.Select(f => new
             {
                 Key = f.Key,

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -3,10 +3,12 @@
 @using System.Text.Json
 @using DynamicFormsApp.Client.Components
 @using DynamicFormsApp.Shared
+@using DynamicFormsApp.Shared.Models
 @inject IJSRuntime JS
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
+@inject IUserService UserService
 
 @implements IDisposable
 
@@ -26,6 +28,17 @@
     <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" />
     <label class="form-check-label" for="loginToggle">Require login to access form</label>
 </div>
+<div class="form-check form-switch mb-4">
+    <input class="form-check-input" type="checkbox" id="notifyToggle" @bind="notifyOnResponse" />
+    <label class="form-check-label" for="notifyToggle">Email on new response</label>
+</div>
+@if (notifyOnResponse)
+{
+    <div class="mb-3">
+        <label class="form-label">Notification Email</label>
+        <input class="form-control" placeholder="@currentUser?.Email" @bind="notificationEmail" />
+    </div>
+}
 
 @if (!isPreviewMode)
 {
@@ -92,6 +105,9 @@ else
     private List<DesignerRow> rows = new() { new DesignerRow() };
     private bool isPreviewMode = false;
     private bool requireLogin = true;
+    private bool notifyOnResponse = false;
+    private string notificationEmail = string.Empty;
+    private UserModel? currentUser;
     private DotNetObjectReference<Index>? objRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -105,6 +121,9 @@ else
                 Navigation.NavigateTo($"login?returnUrl={ret}", true);
                 return;
             }
+
+            currentUser = await UserService.GetUserData(user);
+            notificationEmail = currentUser?.Email ?? string.Empty;
 
             objRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef);
@@ -189,6 +208,9 @@ else
         {
             Name = formName,
             RequireLogin = requireLogin,
+            NotifyOnResponse = notifyOnResponse,
+            NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
+            IsActive = true,
             Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
             {
                 f.Key,

--- a/Client/Pages/DynamicForms/MyForms.razor
+++ b/Client/Pages/DynamicForms/MyForms.razor
@@ -33,7 +33,8 @@ else
                         <td>
                             <a class="btn btn-sm btn-primary me-2" href="@($"/forms/{f.Id}")">Open</a>
                             <a class="btn btn-sm btn-secondary me-2" href="@($"/forms/{f.Id}/responses")">Responses</a>
-                            <a class="btn btn-sm btn-info" href="@($"/forms/{f.Id}/summary")">Summary</a>
+                            <a class="btn btn-sm btn-info me-2" href="@($"/forms/{f.Id}/summary")">Summary</a>
+                            <button class="btn btn-sm btn-danger" @onclick="() => DeleteForm(f.Id)">Delete</button>
                         </td>
                     </tr>
                 }
@@ -60,5 +61,35 @@ else
             forms = await Http.GetFromJsonAsync<List<Form>>("api/forms/mine");
             StateHasChanged();
         }
+    }
+
+    private async Task DeleteForm(int id)
+    {
+        var item = forms?.FirstOrDefault(f => f.Id == id);
+        if (item == null)
+        {
+            return;
+        }
+
+        bool? confirmed = await DialogService.Confirm(
+            "Are you sure you want to delete this form?",
+            "Delete Form",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+
+        if (confirmed != true)
+        {
+            return;
+        }
+
+        await Http.DeleteAsync($"api/forms/{id}");
+
+        forms!.Remove(item);
+        NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Success,
+                Summary = "Form Deleted",
+                Detail = item.Name
+            });
+        StateHasChanged();
     }
 }

--- a/Client/Pages/DynamicForms/SearchForms.razor
+++ b/Client/Pages/DynamicForms/SearchForms.razor
@@ -1,0 +1,63 @@
+@page "/forms/search"
+@using System.Net.Http.Json
+@inject HttpClient Http
+@inject NavigationManager Navigation
+@inject CookieHelper CookieHelper
+
+<h3 class="mb-3">Search Forms</h3>
+
+<input class="form-control mb-3" placeholder="Search..." @bind="searchTerm" />
+
+@if (forms == null)
+{
+    <p>Loading...</p>
+}
+else if (!FilteredForms.Any())
+{
+    <p>No matching forms.</p>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var f in FilteredForms)
+                {
+                    <tr>
+                        <td>@f.Name</td>
+                        <td>
+                            <a class="btn btn-sm btn-primary" href="@($"/forms/{f.Id}")">Open</a>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@code {
+    private List<Form>? forms;
+    private string searchTerm = string.Empty;
+
+    private IEnumerable<Form> FilteredForms => string.IsNullOrWhiteSpace(searchTerm)
+        ? forms ?? Enumerable.Empty<Form>()
+        : forms?.Where(f => f.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+            ?? Enumerable.Empty<Form>();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var user = await CookieHelper.LoginStatus();
+            bool includePrivate = !string.IsNullOrEmpty(user);
+            forms = await Http.GetFromJsonAsync<List<Form>>($"api/forms/search?includePrivate={includePrivate}");
+            StateHasChanged();
+        }
+    }
+}

--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -1,14 +1,17 @@
 @page "/"
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
+@inject HttpClient Http
 
 <h3 class="mb-3">Welcome</h3>
+<p class="text-muted">Total forms created: @totalForms</p>
 <div class="d-flex gap-3">
     <a href="/forms/new" class="btn btn-primary">Create Form</a>
     <a href="/myforms" class="btn btn-secondary">My Forms</a>
 </div>
 
 @code {
+    private int totalForms;
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
@@ -18,6 +21,12 @@
             {
                 var ret = Uri.EscapeDataString(Navigation.ToBaseRelativePath(Navigation.Uri));
                 Navigation.NavigateTo($"login?returnUrl={ret}", true);
+            }
+            else
+            {
+                var forms = await Http.GetFromJsonAsync<List<Form>>("api/forms");
+                totalForms = forms?.Count(f => f.IsActive) ?? 0;
+                StateHasChanged();
             }
         }
     }

--- a/Client/Services/EmailServiceProxy.cs
+++ b/Client/Services/EmailServiceProxy.cs
@@ -19,5 +19,11 @@ namespace DynamicFormsApp.Client.Services
         {
             await _httpClient.PostAsJsonAsync("api/email/bug/", email);
         }
+
+        public async Task SendFormResponseNotification(string toEmail, string formName, int formId)
+        {
+            var payload = new { toEmail, formName, formId };
+            await _httpClient.PostAsJsonAsync("api/email/formresponse", payload);
+        }
     }
 }

--- a/NdaProcesses.Shared/Models/CreateFormDto.cs
+++ b/NdaProcesses.Shared/Models/CreateFormDto.cs
@@ -13,5 +13,8 @@ namespace DynamicFormsApp.Server.Services
         public string Name { get; set; }
         public List<FormField> Fields { get; set; }
         public bool RequireLogin { get; set; } = true;
+        public bool NotifyOnResponse { get; set; } = false;
+        public string? NotificationEmail { get; set; }
+        public bool IsActive { get; set; } = true;
     }
 }

--- a/NdaProcesses.Shared/Models/Form.cs
+++ b/NdaProcesses.Shared/Models/Form.cs
@@ -14,6 +14,9 @@ namespace DynamicFormsApp.Shared.Models
         public string Name { get; set; }
         public string CreatedBy { get; set; }
         public bool RequireLogin { get; set; } = true;
+        public bool NotifyOnResponse { get; set; } = false;
+        public string? NotificationEmail { get; set; }
+        public bool IsActive { get; set; } = true;
         public List<FormField>? Fields { get; set; }
     }
 }

--- a/NdaProcesses.Shared/Services/IEmailService.cs
+++ b/NdaProcesses.Shared/Services/IEmailService.cs
@@ -6,5 +6,6 @@ namespace DynamicFormsApp.Shared.Services
     public interface IEmailService
     {
         Task SendBugReportEmail(EmailModel email);
+        Task SendFormResponseNotification(string toEmail, string formName, int formId);
     }
 }

--- a/Server/Controllers/EmailController.cs
+++ b/Server/Controllers/EmailController.cs
@@ -22,5 +22,19 @@ namespace DynamicFormsApp.Server.Controllers
             await _emailService.SendBugReportEmail(email);
             return Ok();
         }
+
+        [HttpPost("formresponse")]
+        public async Task<IActionResult> SendFormResponseEmail([FromBody] FormResponseNotification model)
+        {
+            await _emailService.SendFormResponseNotification(model.toEmail, model.formName, model.formId);
+            return Ok();
+        }
+
+        public class FormResponseNotification
+        {
+            public string toEmail { get; set; }
+            public string formName { get; set; }
+            public int formId { get; set; }
+        }
     }
 }

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -1,5 +1,6 @@
 ﻿using DynamicFormsApp.Server.Services;
 using DynamicFormsApp.Shared.Models;
+using DynamicFormsApp.Shared.Services;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -11,9 +12,14 @@ namespace DynamicFormsApp.Server.Controllers
     public class FormsController : ControllerBase
     {
         private readonly DynamicFormService _svc;
-        public FormsController(DynamicFormService svc)
+        private readonly IUserService _userSvc;
+        private readonly IEmailService _emailSvc;
+
+        public FormsController(DynamicFormService svc, IUserService userSvc, IEmailService emailSvc)
         {
             _svc = svc;
+            _userSvc = userSvc;
+            _emailSvc = emailSvc;
         }
 
         // POST /api/forms
@@ -25,7 +31,7 @@ namespace DynamicFormsApp.Server.Controllers
                 return Unauthorized();
             }
 
-            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Fields, user, dto.RequireLogin);
+            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Fields, user, dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive);
             return Ok(new { FormId = newFormId });
         }
 
@@ -54,6 +60,14 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok(all);
         }
 
+        [HttpGet("search")]
+        public async Task<ActionResult<IEnumerable<Form>>> Search([FromQuery] bool includePrivate = false)
+        {
+            var loggedIn = Request.Cookies.TryGetValue("userName", out var user) && !string.IsNullOrEmpty(user);
+            var results = await _svc.SearchFormsAsync(loggedIn && includePrivate);
+            return Ok(results);
+        }
+
         [HttpGet("mine")]
         public async Task<ActionResult<IEnumerable<Form>>> GetMine()
         {
@@ -66,6 +80,19 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok(mine);
         }
 
+        // DELETE /api/forms/{id}
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+
+            await _svc.DeactivateFormAsync(id, user);
+            return NoContent();
+        }
+
         // POST /api/forms/{id}/responses
         [HttpPost("{id}/responses")]
 
@@ -73,8 +100,26 @@ namespace DynamicFormsApp.Server.Controllers
         {
             try
             {
+                var form = await _svc.StoreResponseAsync(id, values);
 
-                await _svc.StoreResponseAsync(id, values);
+                if (form.NotifyOnResponse)
+                {
+                    string? to = form.NotificationEmail;
+                    if (string.IsNullOrWhiteSpace(to))
+                    {
+                        var user = await _userSvc.GetUserData(form.CreatedBy);
+                        if (user != null && !string.IsNullOrEmpty(user.Email))
+                        {
+                            to = user.Email;
+                        }
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(to))
+                    {
+                        await _emailSvc.SendFormResponseNotification(to, form.Name, form.Id);
+                    }
+                }
+
                 return NoContent();
             }
             catch (Exception ex)

--- a/Server/Services/CreateFormDto.cs
+++ b/Server/Services/CreateFormDto.cs
@@ -8,6 +8,9 @@ namespace DynamicFormsApp.Server.Services
         public string Name { get; set; }
         public List<FormField> Fields { get; set; }
         public bool RequireLogin { get; set; } = true;
+        public bool NotifyOnResponse { get; set; } = false;
+        public string? NotificationEmail { get; set; }
+        public bool IsActive { get; set; } = true;
         public string? CreatedBy { get; set; }
     }
 }

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -24,13 +24,16 @@ namespace DynamicFormsApp.Server.Services
         private string SanitizeKey(string raw) =>
             Regex.Replace(raw, @"[^\w]", "_");
 
-        public async Task<int> CreateFormAsync(string formName, List<FormField> fields, string createdBy, bool requireLogin)
+        public async Task<int> CreateFormAsync(string formName, List<FormField> fields, string createdBy, bool requireLogin, bool notifyOnResponse, string? notificationEmail, bool isActive)
         {
             var form = new Form
             {
                 Name = formName,
                 CreatedBy = createdBy,
                 RequireLogin = requireLogin,
+                NotifyOnResponse = notifyOnResponse,
+                NotificationEmail = notificationEmail,
+                IsActive = isActive,
                 Fields = fields.Select(f => new FormField
                 {
                     Key = SanitizeKey(f.Key),
@@ -70,7 +73,7 @@ namespace DynamicFormsApp.Server.Services
                 ?? throw new InvalidOperationException("Form not found");
         }
 
-        public async Task StoreResponseAsync(int formId, Dictionary<string, object> values)
+        public async Task<Form> StoreResponseAsync(int formId, Dictionary<string, object> values)
         {
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
@@ -116,20 +119,49 @@ namespace DynamicFormsApp.Server.Services
 
             sqlParams.Add(new SqlParameter("@p_created", DateTime.UtcNow));
             await _db.Database.ExecuteSqlRawAsync(sql, sqlParams.ToArray());
+
+            return form;
+        }
+
+        public async Task DeactivateFormAsync(int formId, string user)
+        {
+            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId && f.CreatedBy == user);
+            if (form == null)
+            {
+                throw new InvalidOperationException("Form not found");
+            }
+
+            form.IsActive = false;
+            await _db.SaveChangesAsync();
         }
 
         public async Task<List<Form>> GetAllFormsAsync()
         {
             return await _db.Forms
                 .Include(f => f.Fields)
+                .Where(f => f.IsActive)
                 .ToListAsync();
+        }
+
+        public async Task<List<Form>> SearchFormsAsync(bool includePrivate)
+        {
+            var query = _db.Forms
+                .Include(f => f.Fields)
+                .Where(f => f.IsActive);
+
+            if (!includePrivate)
+            {
+                query = query.Where(f => !f.RequireLogin);
+            }
+
+            return await query.ToListAsync();
         }
 
         public async Task<List<Form>> GetFormsByUserAsync(string user)
         {
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.CreatedBy == user)
+                .Where(f => f.CreatedBy == user && f.IsActive)
                 .ToListAsync();
         }
 

--- a/Server/Services/EmailService.cs
+++ b/Server/Services/EmailService.cs
@@ -49,5 +49,28 @@ namespace DynamicFormsApp.Server.Services
             };
             await client.SendMailAsync(mail);
         }
+
+        public async Task SendFormResponseNotification(string toEmail, string formName, int formId)
+        {
+            var baseUrl = _configuration["AppBaseUrl"]?.TrimEnd('/') ?? string.Empty;
+            var responsesLink = $"{baseUrl}/forms/{formId}/responses";
+
+            var mail = new MailMessage
+            {
+                From = new MailAddress("NDABugReport@ntnanderson.com"),
+                Subject = $"Your form '{formName}' received a new response",
+                Body = $"A new response has been submitted for your form '<b>{formName}</b>'.<br/>" +
+                       $"<a href='{responsesLink}'>View responses</a>.",
+                IsBodyHtml = true
+            };
+
+            mail.To.Add(toEmail);
+
+            using var client = new SmtpClient(_configuration["Email:IP"])
+            {
+                Port = int.Parse(_configuration["Email:Port"]!)
+            };
+            await client.SendMailAsync(mail);
+        }
     }
 }

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -14,4 +14,5 @@
     }
   },
   "AllowedHosts": "*"
+  ,"AppBaseUrl": "https://example.com"
 }


### PR DESCRIPTION
## Summary
- display total forms created on the home page
- include a link and friendlier subject in response notification emails
- add `AppBaseUrl` app setting for email links
- allow form owners to soft delete forms via new `IsActive` flag
- confirm delete action and add public form search page
- improved delete UI with Radzen dialog and notification
- only count active forms when displaying the total

## Testing
- `dotnet test DynamicFormsApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685445bda4bc83298199dc85af821ea4