### PR TITLE
Show main form stats and email link

### DIFF
--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -10,10 +10,10 @@
                 <input class="form-control form-control-sm" placeholder="Field label" @bind="Field.Label" />
             </div>
             <div class="d-flex gap-2">
-                <button class="btn btn-sm btn-outline-secondary" @onclick="() => OnDuplicate.InvokeAsync(Field)">
+                <button class="btn btn-sm btn-outline-secondary" title="Duplicate" @onclick="() => OnDuplicate.InvokeAsync(Field)">
                     <i class="bi bi-copy"></i>
                 </button>
-                <button class="btn btn-sm btn-outline-danger" @onclick="() => OnRemove.InvokeAsync(Field)">
+                <button class="btn btn-sm btn-outline-danger" title="Remove" @onclick="() => OnRemove.InvokeAsync(Field)">
                     <i class="bi bi-trash"></i>
                 </button>
             </div>

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -11,10 +11,10 @@
             </div>
             <div class="d-flex gap-2">
                 <button class="btn btn-sm btn-outline-secondary" title="Duplicate" @onclick="() => OnDuplicate.InvokeAsync(Field)">
-                    <i class="bi bi-copy"></i>
+                    <i class="bi bi-files"></i>
                 </button>
                 <button class="btn btn-sm btn-outline-danger" title="Remove" @onclick="() => OnRemove.InvokeAsync(Field)">
-                    <i class="bi bi-trash"></i>
+                    <i class="bi bi-x-lg"></i>
                 </button>
             </div>
         </div>

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -1,5 +1,9 @@
 ﻿@using DynamicFormsApp.Shared
 
+@if (!string.IsNullOrWhiteSpace(FormName))
+{
+    <h4 class="mb-2">@FormName</h4>
+}
 <h5 class="text-muted">Live Preview</h5>
 
 @foreach (var row in Rows)
@@ -122,4 +126,5 @@
 
 @code {
     [Parameter] public List<DesignerRow> Rows { get; set; } = new();
+    [Parameter] public string FormName { get; set; } = string.Empty;
 }

--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -54,6 +54,7 @@
             <RadzenPanelMenuItem Text="Home" Path="" Icon="Home"/>
             <RadzenPanelMenuItem Text="Create Form" Path="forms/new" Icon="add_box" />
             <RadzenPanelMenuItem Text="My Forms" Path="myforms" Icon="list" />
+            <RadzenPanelMenuItem Text="Search Forms" Path="forms/search" Icon="search" />
         </RadzenPanelMenu>
 
         <!-- Footer section of the sidebar -->

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -141,6 +141,17 @@
 
     async Task HandleSubmit()
     {
+        if (string.IsNullOrWhiteSpace(formName))
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Form name required",
+                Detail = "Please enter a form name before creating."
+            });
+            return;
+        }
+
         var payload = new
         {
             Name = formName,

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -16,6 +16,10 @@
            placeholder="Enter your form title"
            @bind="formName" />
 </div>
+<div class="mb-4">
+    <label class="form-label">Description</label>
+    <textarea class="form-control" placeholder="Enter a description" @bind="formDescription"></textarea>
+</div>
 
 <div class="form-check form-switch mb-4">
     <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" />
@@ -98,6 +102,7 @@
 
 @code {
     private string formName = string.Empty;
+    private string formDescription = string.Empty;
     private List<DesignerField> fields = new();
     private bool requireLogin = true;
     private bool notifyOnResponse = false;
@@ -139,6 +144,7 @@
         var payload = new
         {
             Name = formName,
+            Description = formDescription,
             RequireLogin = requireLogin,
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -75,7 +75,7 @@
                 </div>
                 <div class="col-md-4">
                     <input type="text" class="form-control"
-                           placeholder="Options (comma-separated)"
+                           placeholder="Option1, Option2, ..."
                            @bind="field.Options" />
                 </div>
             </div>

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -58,10 +58,10 @@
                            @bind="field.Label" />
                 </div>
                 <div class="btn-group">
-                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => DuplicateField(index)">
+                    <button class="btn btn-sm btn-outline-secondary" title="Duplicate" @onclick="() => DuplicateField(index)">
                         <i class="bi bi-copy"></i>
                     </button>
-                    <button class="btn btn-sm btn-outline-danger" @onclick="() => RemoveField(field)">
+                    <button class="btn btn-sm btn-outline-danger" title="Remove" @onclick="() => RemoveField(field)">
                         <i class="bi bi-trash"></i>
                     </button>
                 </div>

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -59,10 +59,10 @@
                 </div>
                 <div class="btn-group">
                     <button class="btn btn-sm btn-outline-secondary" title="Duplicate" @onclick="() => DuplicateField(index)">
-                        <i class="bi bi-copy"></i>
+                        <i class="bi bi-files"></i>
                     </button>
                     <button class="btn btn-sm btn-outline-danger" title="Remove" @onclick="() => RemoveField(field)">
-                        <i class="bi bi-trash"></i>
+                        <i class="bi bi-x-lg"></i>
                     </button>
                 </div>
             </div>

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -1,6 +1,8 @@
 ﻿@page "/razer"
 @using System.Net.Http.Json
 @using System.Text.Json
+@using DynamicFormsApp.Shared.Models
+@inject IUserService UserService
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
@@ -19,6 +21,17 @@
     <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" />
     <label class="form-check-label" for="loginToggle">Require login to access form</label>
 </div>
+<div class="form-check form-switch mb-4">
+    <input class="form-check-input" type="checkbox" id="notifyToggle" @bind="notifyOnResponse" />
+    <label class="form-check-label" for="notifyToggle">Email on new response</label>
+</div>
+@if (notifyOnResponse)
+{
+    <div class="mb-3">
+        <label class="form-label">Notification Email</label>
+        <input class="form-control" placeholder="@currentUser?.Email" @bind="notificationEmail" />
+    </div>
+}
 
 @foreach (var field in fields)
 {
@@ -87,6 +100,9 @@
     private string formName = string.Empty;
     private List<DesignerField> fields = new();
     private bool requireLogin = true;
+    private bool notifyOnResponse = false;
+    private string notificationEmail = string.Empty;
+    private UserModel? currentUser;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -97,6 +113,11 @@
             {
                 var ret = Uri.EscapeDataString(Navigation.ToBaseRelativePath(Navigation.Uri));
                 Navigation.NavigateTo($"login?returnUrl={ret}", true);
+            }
+            else
+            {
+                currentUser = await UserService.GetUserData(user);
+                notificationEmail = currentUser?.Email ?? string.Empty;
             }
         }
     }
@@ -119,6 +140,9 @@
         {
             Name = formName,
             RequireLogin = requireLogin,
+            NotifyOnResponse = notifyOnResponse,
+            NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
+            IsActive = true,
             Fields = fields.Select(f => new
             {
                 Key = f.Key,

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -157,19 +157,21 @@
         public bool IsRequired { get; set; }
     }
 
-    void AddField()
+    async Task AddField()
     {
         fields.Add(new DesignerField());
-        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 
-    void RemoveField(DesignerField field)
+    async Task RemoveField(DesignerField field)
     {
         fields.Remove(field);
-        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 
-    void DuplicateField(int index)
+    async Task DuplicateField(int index)
     {
         var src = fields[index];
         var copy = new DesignerField
@@ -181,7 +183,8 @@
             IsRequired = src.IsRequired
         };
         fields.Insert(index + 1, copy);
-        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 
     [JSInvokable]

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -2,10 +2,14 @@
 @using System.Net.Http.Json
 @using System.Text.Json
 @using DynamicFormsApp.Shared.Models
+@using Microsoft.JSInterop
 @inject IUserService UserService
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
+@inject IJSRuntime JS
+@implements IDisposable
+@inject IJSRuntime JS
 
 <h2 class="mb-4">Form Builder</h2>
 
@@ -37,18 +41,30 @@
     </div>
 }
 
-@foreach (var field in fields)
+<div id="simple-fields">
+@for (int index = 0; index < fields.Count; index++)
 {
-    <div class="card mb-3 shadow-sm border-start border-5 border-primary">
+    var field = fields[index];
+    <div class="card mb-3 shadow-sm border-start border-5 border-primary" data-idx="@index">
         <div class="card-body">
-            <div class="d-flex justify-content-between">
-                <input type="text"
-                       class="form-control form-control-sm mb-2"
-                       placeholder="Question/Label"
-                       @bind="field.Label" />
-                <button class="btn btn-outline-danger btn-sm" @onclick="() => RemoveField(field)">
-                    <i class="bi bi-trash"></i>
-                </button>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <div class="d-flex align-items-center gap-2">
+                    <button type="button" class="btn btn-sm btn-outline-secondary move-handle">
+                        <i class="bi bi-grip-vertical"></i>
+                    </button>
+                    <input type="text"
+                           class="form-control form-control-sm"
+                           placeholder="Question/Label"
+                           @bind="field.Label" />
+                </div>
+                <div class="btn-group">
+                    <button class="btn btn-sm btn-outline-secondary" @onclick="() => DuplicateField(index)">
+                        <i class="bi bi-copy"></i>
+                    </button>
+                    <button class="btn btn-sm btn-outline-danger" @onclick="() => RemoveField(field)">
+                        <i class="bi bi-trash"></i>
+                    </button>
+                </div>
             </div>
 
             <div class="row g-2 align-items-center">
@@ -87,6 +103,7 @@
         </div>
     </div>
 }
+</div>
 
 <div class="d-grid mb-3">
     <button class="btn btn-outline-secondary" @onclick="AddField">
@@ -108,6 +125,7 @@
     private bool notifyOnResponse = false;
     private string notificationEmail = string.Empty;
     private UserModel? currentUser;
+    private DotNetObjectReference<FormDesigner>? objRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -124,6 +142,9 @@
                 currentUser = await UserService.GetUserData(user);
                 notificationEmail = currentUser?.Email ?? string.Empty;
             }
+
+            objRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef);
         }
     }
 
@@ -136,8 +157,43 @@
         public bool IsRequired { get; set; }
     }
 
-    void AddField() => fields.Add(new DesignerField());
-    void RemoveField(DesignerField field) => fields.Remove(field);
+    void AddField()
+    {
+        fields.Add(new DesignerField());
+        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+    }
+
+    void RemoveField(DesignerField field)
+    {
+        fields.Remove(field);
+        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+    }
+
+    void DuplicateField(int index)
+    {
+        var src = fields[index];
+        var copy = new DesignerField
+        {
+            Key = src.Key + "_copy",
+            Label = src.Label,
+            FieldType = src.FieldType,
+            Options = src.Options,
+            IsRequired = src.IsRequired
+        };
+        fields.Insert(index + 1, copy);
+        JS.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+    }
+
+    [JSInvokable]
+    public void OnFieldReorder(int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 || oldIndex >= fields.Count || newIndex >= fields.Count)
+            return;
+        var item = fields[oldIndex];
+        fields.RemoveAt(oldIndex);
+        fields.Insert(newIndex, item);
+        StateHasChanged();
+    }
 
     async Task HandleSubmit()
     {
@@ -185,5 +241,10 @@
         {
             // TODO: Error alert
         }
+    }
+
+    public void Dispose()
+    {
+        objRef?.Dispose();
     }
 }

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -208,6 +208,32 @@
             return;
         }
 
+        foreach (var f in fields)
+        {
+            if (string.IsNullOrWhiteSpace(f.Key) || string.IsNullOrWhiteSpace(f.Label))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Field details missing",
+                    Detail = "Each field needs a key and a label."
+                });
+                return;
+            }
+
+            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") &&
+                f.Options.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Length == 0)
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options required",
+                    Detail = $"Add at least one option for '{f.Label}'."
+                });
+                return;
+            }
+        }
+
         var payload = new
         {
             Name = formName,
@@ -239,7 +265,12 @@
         }
         else
         {
-            // TODO: Error alert
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Error,
+                Summary = "Error",
+                Detail = "Failed to create form."
+            });
         }
     }
 

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -31,7 +31,7 @@ else
             {
                 <div class="col-md-@(12 / (rowGroup.Count() == 0 ? 1 : rowGroup.Count()))">
                     <div class="mb-3">
-                        <label class="form-label">@fld.Label</label>
+                        <label class="form-label fw-semibold">@fld.Label</label>
 
                 @switch (fld.FieldType)
                 {

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -2,6 +2,7 @@
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using System.Text.Json
+@using System.Linq
 @using DynamicFormsApp.Shared.Models
 @inject HttpClient Http
 @inject NavigationManager Navigation
@@ -31,7 +32,13 @@ else
             {
                 <div class="col-md-@(12 / (rowGroup.Count() == 0 ? 1 : rowGroup.Count()))">
                     <div class="mb-3">
-                        <label class="form-label fw-semibold">@fld.Label</label>
+                        <label class="form-label fw-semibold">
+                            @fld.Label
+                            @if (fld.IsRequired)
+                            {
+                                <span class="text-danger"> *</span>
+                            }
+                        </label>
 
                 @switch (fld.FieldType)
                 {
@@ -278,8 +285,33 @@ else
 
     private async Task SubmitResponse()
     {
+        foreach (var fld in form.Fields)
+        {
+            if (!fld.IsRequired)
+                continue;
+
+            if (!responseData.TryGetValue(fld.Key, out var val) || IsEmpty(val))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Missing answer",
+                    Detail = $"Please fill out '{fld.Label}'."
+                });
+                return;
+            }
+        }
+
         await Http.PostAsJsonAsync($"api/forms/{FormId}/responses", responseData);
         Navigation.NavigateTo($"/forms/{FormId}/responses");
+    }
+
+    bool IsEmpty(object value)
+    {
+        if (value == null) return true;
+        if (value is string s) return string.IsNullOrWhiteSpace(s);
+        if (value is IEnumerable<string> list) return !list.Any();
+        return false;
     }
 
     private class FileUploadResult

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -8,6 +8,7 @@
 @inject CookieHelper CookieHelper
 
 <h3>@(form?.Name ?? "Loading…")</h3>
+<p class="text-muted">@form?.Description</p>
 
 @if (form == null)
 {

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -33,6 +33,7 @@
                         {
                             <th scope="col">@col</th>
                         }
+                        <th scope="col"></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -71,6 +72,9 @@
                                     }
                                 </td>
                             }
+                            <td>
+                                <a class="btn btn-sm btn-outline-primary" href="@($"/forms/{FormId}/responses/{row["ResponseId"]}")">View</a>
+                            </td>
                         </tr>
                     }
                 </tbody>

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -106,12 +106,15 @@
             responses = await Http.GetFromJsonAsync<List<Dictionary<string, object>>>($"api/forms/{FormId}/responses");
 
             var fieldKeys = form.Fields.Select(f => f.Key);
-            columns = new[] { "ResponseId", "CreatedAt" }.Concat(fieldKeys);
+            columns = new[] { "ResponseId", "CreatedAt" }
+                .Concat(fieldKeys)
+                .ToArray();
             if (form.RequireLogin)
             {
-                columns = columns.Concat(new[] { "ResponderName" });
+                columns = columns
+                    .Concat(new[] { "ResponderName" })
+                    .ToArray();
             }
-            columns = columns.ToArray();
 
             StateHasChanged();
         }

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -31,7 +31,7 @@
                     <tr>
                         @foreach (var col in columns)
                         {
-                            <th scope="col">@col</th>
+                            <th scope="col">@(col == "ResponderName" ? "Submitted By" : col)</th>
                         }
                         <th scope="col"></th>
                     </tr>
@@ -106,7 +106,12 @@
             responses = await Http.GetFromJsonAsync<List<Dictionary<string, object>>>($"api/forms/{FormId}/responses");
 
             var fieldKeys = form.Fields.Select(f => f.Key);
-            columns = new[] { "ResponseId", "CreatedAt" }.Concat(fieldKeys).ToArray();
+            columns = new[] { "ResponseId", "CreatedAt" }.Concat(fieldKeys);
+            if (form.RequireLogin)
+            {
+                columns = columns.Concat(new[] { "ResponderName" });
+            }
+            columns = columns.ToArray();
 
             StateHasChanged();
         }

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -9,6 +9,7 @@
 
 <div class="container mt-4">
     <h2 class="mb-4">📄 Responses: <span class="text-primary">@form?.Name</span></h2>
+    <p class="text-muted">@form?.Description</p>
 
     @if (form == null || responses == null)
     {

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -7,6 +7,7 @@
 @inject CookieHelper CookieHelper
 
 <h3>Summary for @form?.Name</h3>
+<p class="text-muted">@form?.Description</p>
 
 @if (form == null || responses == null)
 {

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -247,6 +247,17 @@ else
 
     async Task HandleSubmit()
     {
+        if (string.IsNullOrWhiteSpace(formName))
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Form name required",
+                Detail = "Please enter a form name before creating."
+            });
+            return;
+        }
+
         var payload = new
         {
             Name = formName,

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -101,7 +101,7 @@
 else
 {
     <div class="card p-3 shadow-sm">
-        <LivePreview Rows="rows" />
+        <LivePreview Rows="rows" FormName="formName" />
     </div>
 }
 
@@ -115,6 +115,7 @@ else
     private string notificationEmail = string.Empty;
     private UserModel? currentUser;
     private DotNetObjectReference<Index>? objRef;
+    private bool lastPreviewMode;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -130,11 +131,16 @@ else
 
             currentUser = await UserService.GetUserData(user);
             notificationEmail = currentUser?.Email ?? string.Empty;
+        }
 
+        if (!isPreviewMode && (firstRender || lastPreviewMode))
+        {
             objRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef);
             await JS.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
         }
+
+        lastPreviewMode = isPreviewMode;
     }
 
     [JSInvokable]

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -23,6 +23,10 @@
     <label class="form-label">Form Name</label>
     <input class="form-control form-control-lg" placeholder="Enter your form title" @bind="formName" />
 </div>
+<div class="mb-4">
+    <label class="form-label">Description</label>
+    <textarea class="form-control" placeholder="Enter a description" @bind="formDescription"></textarea>
+</div>
 
 <div class="form-check form-switch mb-4">
     <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" />
@@ -102,6 +106,7 @@ else
 
 @code {
     private string formName = string.Empty;
+    private string formDescription = string.Empty;
     private List<DesignerRow> rows = new() { new DesignerRow() };
     private bool isPreviewMode = false;
     private bool requireLogin = true;
@@ -207,6 +212,7 @@ else
         var payload = new
         {
             Name = formName,
+            Description = formDescription,
             RequireLogin = requireLogin,
             NotifyOnResponse = notifyOnResponse,
             NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -157,7 +157,7 @@ else
                 Summary = "Column limit reached",
                 Detail = "A row can contain at most four columns."
             });
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
             return;
         }
 
@@ -170,6 +170,7 @@ else
     async Task AddRow()
     {
         rows.Add(new DesignerRow());
+        await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
@@ -186,12 +187,14 @@ else
             return;
         }
         rows[row].Fields.Add(new DesignerField());
+        await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
     async Task RemoveField(int row, DesignerField field)
     {
         rows[row].Fields.Remove(field);
+        await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
@@ -211,6 +214,7 @@ else
         };
         var list = rows[row].Fields;
         list.Insert(list.IndexOf(field) + 1, copy);
+        await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
@@ -231,7 +235,7 @@ else
                 Summary = "Column limit reached",
                 Detail = "A row can contain at most four columns."
             });
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
             return;
         }
 
@@ -240,7 +244,7 @@ else
         else
             list.Insert(colIndex, field);
 
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
@@ -253,7 +257,7 @@ else
         var row = new DesignerRow();
         row.Fields.Add(new DesignerField { FieldType = fieldType });
         rows.Insert(insertIndex, row);
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -12,7 +12,8 @@
 
 @implements IDisposable
 
-<h2 class="mb-4">Form Builder</h2>
+<h2 class="mb-2">Form Builder</h2>
+<p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
 
 <div class="form-check form-switch mb-4">
     <input class="form-check-input" type="checkbox" id="previewToggle" @bind="isPreviewMode" />
@@ -148,6 +149,18 @@ else
         if (oldIndex < 0 || oldIndex >= source.Count || newIndex < 0 || newIndex > dest.Count)
             return;
 
+        if (fromRow != toRow && dest.Count >= 4)
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Column limit reached",
+                Detail = "A row can contain at most four columns."
+            });
+            StateHasChanged();
+            return;
+        }
+
         var moved = source[oldIndex];
         source.RemoveAt(oldIndex);
         dest.Insert(newIndex, moved);
@@ -156,7 +169,20 @@ else
 
     void AddRow() => rows.Add(new DesignerRow());
 
-    void AddField(int row) => rows[row].Fields.Add(new DesignerField());
+    void AddField(int row)
+    {
+        if (rows[row].Fields.Count >= 4)
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Column limit reached",
+                Detail = "A row can contain at most four columns."
+            });
+            return;
+        }
+        rows[row].Fields.Add(new DesignerField());
+    }
 
     void RemoveField(int row, DesignerField field) => rows[row].Fields.Remove(field);
 
@@ -186,6 +212,18 @@ else
 
         var list = rows[rowIndex].Fields;
         var field = new DesignerField { FieldType = fieldType };
+
+        if (list.Count >= 4)
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Column limit reached",
+                Detail = "A row can contain at most four columns."
+            });
+            StateHasChanged();
+            return;
+        }
 
         if (colIndex < 0 || colIndex > list.Count)
             list.Add(field);

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -48,7 +48,7 @@
 @if (!isPreviewMode)
 {
     <div class="row">
-        <div class="col-md-3">
+        <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
             <h5 class="mb-3">Toolbox</h5>
             <div class="d-flex flex-column gap-2">
                 <div class="draggable-field" draggable="true" data-type="text"><span class="material-icons me-1">short_text</span> Short Answer</div>
@@ -78,8 +78,8 @@
                         {
                             <div class="col-md-@(12 / (rows[rowIndex].Fields.Count == 0 ? 1 : rows[rowIndex].Fields.Count))" data-id="@i">
                                 <FieldEditor Field="rows[rowIndex].Fields[i]"
-                                             OnRemove="f => RemoveField(rowIndex, f)"
-                                             OnDuplicate="f => DuplicateField(rowIndex, f)" />
+                                             OnRemove="async f => await RemoveField(rowIndex, f)"
+                                             OnDuplicate="async f => await DuplicateField(rowIndex, f)" />
                             </div>
                         }
                         <div class="col-12">
@@ -167,9 +167,13 @@ else
         StateHasChanged();
     }
 
-    void AddRow() => rows.Add(new DesignerRow());
+    async Task AddRow()
+    {
+        rows.Add(new DesignerRow());
+        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+    }
 
-    void AddField(int row)
+    async Task AddField(int row)
     {
         if (rows[row].Fields.Count >= 4)
         {
@@ -182,11 +186,16 @@ else
             return;
         }
         rows[row].Fields.Add(new DesignerField());
+        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
-    void RemoveField(int row, DesignerField field) => rows[row].Fields.Remove(field);
+    async Task RemoveField(int row, DesignerField field)
+    {
+        rows[row].Fields.Remove(field);
+        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+    }
 
-    void DuplicateField(int row, DesignerField field)
+    async Task DuplicateField(int row, DesignerField field)
     {
         var copy = new DesignerField
         {
@@ -202,10 +211,11 @@ else
         };
         var list = rows[row].Fields;
         list.Insert(list.IndexOf(field) + 1, copy);
+        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
     [JSInvokable]
-    public void AddFieldFromDrop(string fieldType, int rowIndex, int colIndex)
+    public async Task AddFieldFromDrop(string fieldType, int rowIndex, int colIndex)
     {
         if (rowIndex < 0 || rowIndex >= rows.Count)
             rowIndex = rows.Count - 1;
@@ -231,10 +241,11 @@ else
             list.Insert(colIndex, field);
 
         StateHasChanged();
+        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
     [JSInvokable]
-    public void AddRowFromDrop(string fieldType, int insertIndex)
+    public async Task AddRowFromDrop(string fieldType, int insertIndex)
     {
         if (insertIndex < 0 || insertIndex > rows.Count)
             insertIndex = rows.Count;
@@ -243,6 +254,7 @@ else
         row.Fields.Add(new DesignerField { FieldType = fieldType });
         rows.Insert(insertIndex, row);
         StateHasChanged();
+        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
     }
 
     async Task HandleSubmit()

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -50,7 +50,7 @@
     <div class="row">
         <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
             <h5 class="mb-3">Toolbox</h5>
-            <div class="d-flex flex-column gap-2">
+            <div class="d-flex flex-wrap gap-2">
                 <div class="draggable-field" draggable="true" data-type="text"><span class="material-icons me-1">short_text</span> Short Answer</div>
                 <div class="draggable-field" draggable="true" data-type="textarea"><span class="material-icons me-1">notes</span> Paragraph</div>
                 <div class="draggable-field" draggable="true" data-type="radio"><span class="material-icons me-1">radio_button_checked</span> Multiple Choice</div>

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -270,6 +270,31 @@ else
             return;
         }
 
+        foreach (var f in rows.SelectMany(r => r.Fields))
+        {
+            if (string.IsNullOrWhiteSpace(f.Key) || string.IsNullOrWhiteSpace(f.Label))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Field details missing",
+                    Detail = "Each field needs a key and a label."
+                });
+                return;
+            }
+
+            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") && f.OptionItems.Count == 0)
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options required",
+                    Detail = $"Add at least one option for '{f.Label}'."
+                });
+                return;
+            }
+        }
+
         var payload = new
         {
             Name = formName,

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -73,7 +73,9 @@
                 {
                     var rowIndex = r;
                     <div class="row-dropzone" data-insert="@rowIndex"></div>
-                    <div class="row g-3 mb-3 designer-row" data-row="@rowIndex">
+                    <div class="row-wrapper position-relative mb-3" data-row="@rowIndex">
+                        <span class="row-handle text-muted"><i class="bi bi-grip-vertical"></i></span>
+                        <div class="row g-3 designer-row" data-row="@rowIndex">
                         @for (int i = 0; i < rows[rowIndex].Fields.Count; i++)
                         {
                             <div class="col-md-@(12 / (rows[rowIndex].Fields.Count == 0 ? 1 : rows[rowIndex].Fields.Count))" data-id="@i">
@@ -84,6 +86,7 @@
                         }
                         <div class="col-12">
                             <button class="btn btn-sm btn-outline-secondary" @onclick="() => AddField(rowIndex)">+ Add Column</button>
+                        </div>
                         </div>
                     </div>
                 }
@@ -138,6 +141,7 @@ else
             objRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef);
             await JS.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
+            await JS.InvokeVoidAsync("initRowSortable", "#fields-container", objRef);
         }
 
         lastPreviewMode = isPreviewMode;
@@ -173,11 +177,25 @@ else
         StateHasChanged();
     }
 
+    [JSInvokable]
+    public async Task OnRowReorder(int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 || oldIndex >= rows.Count || newIndex >= rows.Count)
+            return;
+        var row = rows[oldIndex];
+        rows.RemoveAt(oldIndex);
+        rows.Insert(newIndex, row);
+        await InvokeAsync(StateHasChanged);
+        await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
+    }
+
     async Task AddRow()
     {
         rows.Add(new DesignerRow());
         await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
 
     async Task AddField(int row)
@@ -195,6 +213,7 @@ else
         rows[row].Fields.Add(new DesignerField());
         await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
 
     async Task RemoveField(int row, DesignerField field)
@@ -202,6 +221,7 @@ else
         rows[row].Fields.Remove(field);
         await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
 
     async Task DuplicateField(int row, DesignerField field)
@@ -222,6 +242,7 @@ else
         list.Insert(list.IndexOf(field) + 1, copy);
         await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
 
     [JSInvokable]
@@ -252,6 +273,7 @@ else
 
         await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
 
     [JSInvokable]
@@ -265,6 +287,7 @@ else
         rows.Insert(insertIndex, row);
         await InvokeAsync(StateHasChanged);
         await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await JS.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
 
     async Task HandleSubmit()

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -3,10 +3,12 @@
 @using System.Text.Json
 @using DynamicFormsApp.Client.Components
 @using DynamicFormsApp.Shared
+@using DynamicFormsApp.Shared.Models
 @inject IJSRuntime JS
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
+@inject IUserService UserService
 
 @implements IDisposable
 
@@ -26,6 +28,17 @@
     <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" />
     <label class="form-check-label" for="loginToggle">Require login to access form</label>
 </div>
+<div class="form-check form-switch mb-4">
+    <input class="form-check-input" type="checkbox" id="notifyToggle" @bind="notifyOnResponse" />
+    <label class="form-check-label" for="notifyToggle">Email on new response</label>
+</div>
+@if (notifyOnResponse)
+{
+    <div class="mb-3">
+        <label class="form-label">Notification Email</label>
+        <input class="form-control" placeholder="@currentUser?.Email" @bind="notificationEmail" />
+    </div>
+}
 
 @if (!isPreviewMode)
 {
@@ -92,6 +105,9 @@ else
     private List<DesignerRow> rows = new() { new DesignerRow() };
     private bool isPreviewMode = false;
     private bool requireLogin = true;
+    private bool notifyOnResponse = false;
+    private string notificationEmail = string.Empty;
+    private UserModel? currentUser;
     private DotNetObjectReference<Index>? objRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -105,6 +121,9 @@ else
                 Navigation.NavigateTo($"login?returnUrl={ret}", true);
                 return;
             }
+
+            currentUser = await UserService.GetUserData(user);
+            notificationEmail = currentUser?.Email ?? string.Empty;
 
             objRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef);
@@ -189,6 +208,9 @@ else
         {
             Name = formName,
             RequireLogin = requireLogin,
+            NotifyOnResponse = notifyOnResponse,
+            NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
+            IsActive = true,
             Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
             {
                 f.Key,

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -101,7 +101,7 @@
 else
 {
     <div class="card p-3 shadow-sm">
-        <LivePreview Rows="rows" FormName="formName" />
+        <LivePreview Rows="rows" FormName="@formName" />
     </div>
 }
 

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -144,7 +144,7 @@ else
     }
 
     [JSInvokable]
-    public void OnSortUpdate(int fromRow, int oldIndex, int toRow, int newIndex)
+    public async Task OnSortUpdate(int fromRow, int oldIndex, int toRow, int newIndex)
     {
         if (fromRow < 0 || fromRow >= rows.Count || toRow < 0 || toRow >= rows.Count)
             return;

--- a/Client/Pages/DynamicForms/MyForms.razor
+++ b/Client/Pages/DynamicForms/MyForms.razor
@@ -33,7 +33,8 @@ else
                         <td>
                             <a class="btn btn-sm btn-primary me-2" href="@($"/forms/{f.Id}")">Open</a>
                             <a class="btn btn-sm btn-secondary me-2" href="@($"/forms/{f.Id}/responses")">Responses</a>
-                            <a class="btn btn-sm btn-info" href="@($"/forms/{f.Id}/summary")">Summary</a>
+                            <a class="btn btn-sm btn-info me-2" href="@($"/forms/{f.Id}/summary")">Summary</a>
+                            <button class="btn btn-sm btn-danger" @onclick="() => DeleteForm(f.Id)">Delete</button>
                         </td>
                     </tr>
                 }
@@ -60,5 +61,35 @@ else
             forms = await Http.GetFromJsonAsync<List<Form>>("api/forms/mine");
             StateHasChanged();
         }
+    }
+
+    private async Task DeleteForm(int id)
+    {
+        var item = forms?.FirstOrDefault(f => f.Id == id);
+        if (item == null)
+        {
+            return;
+        }
+
+        bool? confirmed = await DialogService.Confirm(
+            "Are you sure you want to delete this form?",
+            "Delete Form",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+
+        if (confirmed != true)
+        {
+            return;
+        }
+
+        await Http.DeleteAsync($"api/forms/{id}");
+
+        forms!.Remove(item);
+        NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Success,
+                Summary = "Form Deleted",
+                Detail = item.Name
+            });
+        StateHasChanged();
     }
 }

--- a/Client/Pages/DynamicForms/MyForms.razor
+++ b/Client/Pages/DynamicForms/MyForms.razor
@@ -22,6 +22,7 @@ else
             <thead>
                 <tr>
                     <th>Name</th>
+                    <th>Description</th>
                     <th></th>
                 </tr>
             </thead>
@@ -30,6 +31,7 @@ else
                 {
                     <tr>
                         <td>@f.Name</td>
+                        <td>@f.Description</td>
                         <td>
                             <a class="btn btn-sm btn-primary me-2" href="@($"/forms/{f.Id}")">Open</a>
                             <a class="btn btn-sm btn-secondary me-2" href="@($"/forms/{f.Id}/responses")">Responses</a>

--- a/Client/Pages/DynamicForms/SearchForms.razor
+++ b/Client/Pages/DynamicForms/SearchForms.razor
@@ -1,0 +1,63 @@
+@page "/forms/search"
+@using System.Net.Http.Json
+@inject HttpClient Http
+@inject NavigationManager Navigation
+@inject CookieHelper CookieHelper
+
+<h3 class="mb-3">Search Forms</h3>
+
+<input class="form-control mb-3" placeholder="Search..." @bind="searchTerm" />
+
+@if (forms == null)
+{
+    <p>Loading...</p>
+}
+else if (!FilteredForms.Any())
+{
+    <p>No matching forms.</p>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var f in FilteredForms)
+                {
+                    <tr>
+                        <td>@f.Name</td>
+                        <td>
+                            <a class="btn btn-sm btn-primary" href="@($"/forms/{f.Id}")">Open</a>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@code {
+    private List<Form>? forms;
+    private string searchTerm = string.Empty;
+
+    private IEnumerable<Form> FilteredForms => string.IsNullOrWhiteSpace(searchTerm)
+        ? forms ?? Enumerable.Empty<Form>()
+        : forms?.Where(f => f.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+            ?? Enumerable.Empty<Form>();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var user = await CookieHelper.LoginStatus();
+            bool includePrivate = !string.IsNullOrEmpty(user);
+            forms = await Http.GetFromJsonAsync<List<Form>>($"api/forms/search?includePrivate={includePrivate}");
+            StateHasChanged();
+        }
+    }
+}

--- a/Client/Pages/DynamicForms/SearchForms.razor
+++ b/Client/Pages/DynamicForms/SearchForms.razor
@@ -23,6 +23,7 @@ else
             <thead>
                 <tr>
                     <th>Name</th>
+                    <th>Description</th>
                     <th></th>
                 </tr>
             </thead>
@@ -31,6 +32,7 @@ else
                 {
                     <tr>
                         <td>@f.Name</td>
+                        <td>@f.Description</td>
                         <td>
                             <a class="btn btn-sm btn-primary" href="@($"/forms/{f.Id}")">Open</a>
                         </td>
@@ -47,7 +49,9 @@ else
 
     private IEnumerable<Form> FilteredForms => string.IsNullOrWhiteSpace(searchTerm)
         ? forms ?? Enumerable.Empty<Form>()
-        : forms?.Where(f => f.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+        : forms?.Where(f =>
+            (f.Name?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            (f.Description?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false))
             ?? Enumerable.Empty<Form>();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -1,0 +1,116 @@
+@page "/forms/{FormId:int}/responses/{ResponseId:int}"
+@using System.Net.Http.Json
+@using System.Text.Json
+@using DynamicFormsApp.Shared.Models
+@inject HttpClient Http
+@inject NavigationManager Navigation
+@inject CookieHelper CookieHelper
+
+<h3>Response for @form?.Name</h3>
+<p class="text-muted">@form?.Description</p>
+
+@if (form == null || response == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    @foreach (var rowGroup in form.Fields.OrderBy(f => f.Row ?? 0).ThenBy(f => f.Column ?? 0).GroupBy(f => f.Row ?? 0))
+    {
+        <div class="row g-3 mb-3">
+        @foreach (var fld in rowGroup)
+        {
+            <div class="col-md-@(12 / (rowGroup.Count() == 0 ? 1 : rowGroup.Count()))">
+                <div class="mb-3">
+                    <label class="form-label">@fld.Label</label>
+                    @DisplayValue(fld)
+                </div>
+            </div>
+        }
+        </div>
+    }
+}
+
+@code {
+    [Parameter] public int FormId { get; set; }
+    [Parameter] public int ResponseId { get; set; }
+
+    private Form? form;
+    private Dictionary<string, object>? response;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var user = await CookieHelper.LoginStatus();
+            if (string.IsNullOrEmpty(user))
+            {
+                var ret = Uri.EscapeDataString(Navigation.ToBaseRelativePath(Navigation.Uri));
+                Navigation.NavigateTo($"login?returnUrl={ret}", true);
+                return;
+            }
+
+            form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
+            response = await Http.GetFromJsonAsync<Dictionary<string, object>>($"api/forms/{FormId}/responses/{ResponseId}");
+            StateHasChanged();
+        }
+    }
+
+    RenderFragment DisplayValue(FormField field) => builder =>
+    {
+        if (response == null) return;
+        response.TryGetValue(field.Key, out var valObj);
+        var val = valObj?.ToString() ?? string.Empty;
+        if (field.FieldType == "file")
+        {
+            if (string.IsNullOrWhiteSpace(val))
+            {
+                builder.AddContent(0, "No file");
+                return;
+            }
+            if (val.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+            {
+                builder.AddMarkupContent(1, $"<iframe src='/{val}' width='100%' height='200px' style='border:none;'></iframe>");
+            }
+            else if (IsImage(val))
+            {
+                builder.AddMarkupContent(2, $"<img src='/{val}' class='img-thumbnail' style='max-height:120px;' />");
+            }
+            else
+            {
+                builder.OpenElement(3, "a");
+                builder.AddAttribute(4, "href", $"/{val}");
+                builder.AddAttribute(5, "target", "_blank");
+                builder.AddContent(6, "Open File");
+                builder.CloseElement();
+            }
+        }
+        else if (field.FieldType == "checkbox")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var list = JsonSerializer.Deserialize<List<string>>(val) ?? new();
+                    builder.AddContent(7, string.Join(", ", list));
+                }
+                catch
+                {
+                    builder.AddContent(8, val);
+                }
+            }
+        }
+        else
+        {
+            builder.AddContent(9, val);
+        }
+    };
+
+    bool IsImage(string path)
+    {
+        var lower = path.ToLowerInvariant();
+        return lower.EndsWith(".jpg") || lower.EndsWith(".jpeg") ||
+               lower.EndsWith(".png") || lower.EndsWith(".gif") ||
+               lower.EndsWith(".bmp") || lower.EndsWith(".webp");
+    }
+}

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -6,7 +6,13 @@
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 
-<h3>Response for @form?.Name</h3>
+<div class="d-flex justify-content-between align-items-center">
+    <h3 class="mb-0">Response for @form?.Name</h3>
+    @if (!string.IsNullOrEmpty(responderName))
+    {
+        <span class="text-muted">Submitted by @responderName</span>
+    }
+</div>
 <p class="text-muted">@form?.Description</p>
 
 @if (form == null || response == null)
@@ -39,6 +45,7 @@ else
 
     private Form? form;
     private Dictionary<string, object>? response;
+    private string? responderName;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -54,6 +61,10 @@ else
 
             form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
             response = await Http.GetFromJsonAsync<Dictionary<string, object>>($"api/forms/{FormId}/responses/{ResponseId}");
+            if (response.TryGetValue("ResponderName", out var respName))
+            {
+                responderName = respName?.ToString();
+            }
             StateHasChanged();
         }
     }

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -22,8 +22,10 @@ else
         {
             <div class="col-md-@(12 / (rowGroup.Count() == 0 ? 1 : rowGroup.Count()))">
                 <div class="mb-3">
-                    <label class="form-label">@fld.Label</label>
-                    @DisplayValue(fld)
+                    <label class="form-label fw-semibold">@fld.Label</label>
+                    <div class="form-control-plaintext border rounded bg-light p-2">
+                        @DisplayValue(fld)
+                    </div>
                 </div>
             </div>
         }

--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -1,14 +1,17 @@
 @page "/"
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
+@inject HttpClient Http
 
 <h3 class="mb-3">Welcome</h3>
+<p class="text-muted">Total forms created: @totalForms</p>
 <div class="d-flex gap-3">
     <a href="/forms/new" class="btn btn-primary">Create Form</a>
     <a href="/myforms" class="btn btn-secondary">My Forms</a>
 </div>
 
 @code {
+    private int totalForms;
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
@@ -18,6 +21,12 @@
             {
                 var ret = Uri.EscapeDataString(Navigation.ToBaseRelativePath(Navigation.Uri));
                 Navigation.NavigateTo($"login?returnUrl={ret}", true);
+            }
+            else
+            {
+                var forms = await Http.GetFromJsonAsync<List<Form>>("api/forms");
+                totalForms = forms?.Count(f => f.IsActive) ?? 0;
+                StateHasChanged();
             }
         }
     }

--- a/Client/Services/EmailServiceProxy.cs
+++ b/Client/Services/EmailServiceProxy.cs
@@ -19,5 +19,11 @@ namespace DynamicFormsApp.Client.Services
         {
             await _httpClient.PostAsJsonAsync("api/email/bug/", email);
         }
+
+        public async Task SendFormResponseNotification(string toEmail, string formName, int formId)
+        {
+            var payload = new { toEmail, formName, formId };
+            await _httpClient.PostAsJsonAsync("api/email/formresponse", payload);
+        }
     }
 }

--- a/NdaProcesses.Shared/Models/CreateFormDto.cs
+++ b/NdaProcesses.Shared/Models/CreateFormDto.cs
@@ -13,5 +13,8 @@ namespace DynamicFormsApp.Server.Services
         public string Name { get; set; }
         public List<FormField> Fields { get; set; }
         public bool RequireLogin { get; set; } = true;
+        public bool NotifyOnResponse { get; set; } = false;
+        public string? NotificationEmail { get; set; }
+        public bool IsActive { get; set; } = true;
     }
 }

--- a/NdaProcesses.Shared/Models/CreateFormDto.cs
+++ b/NdaProcesses.Shared/Models/CreateFormDto.cs
@@ -11,6 +11,7 @@ namespace DynamicFormsApp.Server.Services
     public class CreateFormDto
     {
         public string Name { get; set; }
+        public string? Description { get; set; }
         public List<FormField> Fields { get; set; }
         public bool RequireLogin { get; set; } = true;
         public bool NotifyOnResponse { get; set; } = false;

--- a/NdaProcesses.Shared/Models/Form.cs
+++ b/NdaProcesses.Shared/Models/Form.cs
@@ -12,6 +12,7 @@ namespace DynamicFormsApp.Shared.Models
     {
         public int Id { get; set; }
         public string Name { get; set; }
+        public string? Description { get; set; }
         public string CreatedBy { get; set; }
         public bool RequireLogin { get; set; } = true;
         public bool NotifyOnResponse { get; set; } = false;

--- a/NdaProcesses.Shared/Models/Form.cs
+++ b/NdaProcesses.Shared/Models/Form.cs
@@ -14,6 +14,9 @@ namespace DynamicFormsApp.Shared.Models
         public string Name { get; set; }
         public string CreatedBy { get; set; }
         public bool RequireLogin { get; set; } = true;
+        public bool NotifyOnResponse { get; set; } = false;
+        public string? NotificationEmail { get; set; }
+        public bool IsActive { get; set; } = true;
         public List<FormField>? Fields { get; set; }
     }
 }

--- a/NdaProcesses.Shared/Services/IEmailService.cs
+++ b/NdaProcesses.Shared/Services/IEmailService.cs
@@ -6,5 +6,6 @@ namespace DynamicFormsApp.Shared.Services
     public interface IEmailService
     {
         Task SendBugReportEmail(EmailModel email);
+        Task SendFormResponseNotification(string toEmail, string formName, int formId);
     }
 }

--- a/Server/Controllers/EmailController.cs
+++ b/Server/Controllers/EmailController.cs
@@ -22,5 +22,19 @@ namespace DynamicFormsApp.Server.Controllers
             await _emailService.SendBugReportEmail(email);
             return Ok();
         }
+
+        [HttpPost("formresponse")]
+        public async Task<IActionResult> SendFormResponseEmail([FromBody] FormResponseNotification model)
+        {
+            await _emailService.SendFormResponseNotification(model.toEmail, model.formName, model.formId);
+            return Ok();
+        }
+
+        public class FormResponseNotification
+        {
+            public string toEmail { get; set; }
+            public string formName { get; set; }
+            public int formId { get; set; }
+        }
     }
 }

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -44,6 +44,13 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok(rows);
         }
 
+        [HttpGet("{id}/responses/{responseId}")]
+        public async Task<ActionResult<Dictionary<string, object>>> GetResponse(int id, int responseId)
+        {
+            var row = await _svc.GetResponseAsync(id, responseId);
+            return Ok(row);
+        }
+
 
         // GET /api/forms/{id}
         [HttpGet("{id}")]

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -31,7 +31,7 @@ namespace DynamicFormsApp.Server.Controllers
                 return Unauthorized();
             }
 
-            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Fields, user, dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive);
+            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Description, dto.Fields, user, dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive);
             return Ok(new { FormId = newFormId });
         }
 

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -1,5 +1,6 @@
 ﻿using DynamicFormsApp.Server.Services;
 using DynamicFormsApp.Shared.Models;
+using DynamicFormsApp.Shared.Services;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -11,9 +12,14 @@ namespace DynamicFormsApp.Server.Controllers
     public class FormsController : ControllerBase
     {
         private readonly DynamicFormService _svc;
-        public FormsController(DynamicFormService svc)
+        private readonly IUserService _userSvc;
+        private readonly IEmailService _emailSvc;
+
+        public FormsController(DynamicFormService svc, IUserService userSvc, IEmailService emailSvc)
         {
             _svc = svc;
+            _userSvc = userSvc;
+            _emailSvc = emailSvc;
         }
 
         // POST /api/forms
@@ -25,7 +31,7 @@ namespace DynamicFormsApp.Server.Controllers
                 return Unauthorized();
             }
 
-            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Fields, user, dto.RequireLogin);
+            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Fields, user, dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive);
             return Ok(new { FormId = newFormId });
         }
 
@@ -54,6 +60,14 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok(all);
         }
 
+        [HttpGet("search")]
+        public async Task<ActionResult<IEnumerable<Form>>> Search([FromQuery] bool includePrivate = false)
+        {
+            var loggedIn = Request.Cookies.TryGetValue("userName", out var user) && !string.IsNullOrEmpty(user);
+            var results = await _svc.SearchFormsAsync(loggedIn && includePrivate);
+            return Ok(results);
+        }
+
         [HttpGet("mine")]
         public async Task<ActionResult<IEnumerable<Form>>> GetMine()
         {
@@ -66,6 +80,19 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok(mine);
         }
 
+        // DELETE /api/forms/{id}
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+
+            await _svc.DeactivateFormAsync(id, user);
+            return NoContent();
+        }
+
         // POST /api/forms/{id}/responses
         [HttpPost("{id}/responses")]
 
@@ -73,8 +100,26 @@ namespace DynamicFormsApp.Server.Controllers
         {
             try
             {
+                var form = await _svc.StoreResponseAsync(id, values);
 
-                await _svc.StoreResponseAsync(id, values);
+                if (form.NotifyOnResponse)
+                {
+                    string? to = form.NotificationEmail;
+                    if (string.IsNullOrWhiteSpace(to))
+                    {
+                        var user = await _userSvc.GetUserData(form.CreatedBy);
+                        if (user != null && !string.IsNullOrEmpty(user.Email))
+                        {
+                            to = user.Email;
+                        }
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(to))
+                    {
+                        await _emailSvc.SendFormResponseNotification(to, form.Name, form.Id);
+                    }
+                }
+
                 return NoContent();
             }
             catch (Exception ex)

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -107,7 +107,15 @@ namespace DynamicFormsApp.Server.Controllers
         {
             try
             {
-                var form = await _svc.StoreResponseAsync(id, values);
+                string? responder = null;
+                var form = await _svc.GetFormAsync(id);
+                if (form.RequireLogin && Request.Cookies.TryGetValue("userName", out var userId) && !string.IsNullOrEmpty(userId))
+                {
+                    var userData = await _userSvc.GetUserData(userId);
+                    responder = userData?.DisplayName ?? userId;
+                }
+
+                form = await _svc.StoreResponseAsync(id, values, responder);
 
                 if (form.NotifyOnResponse)
                 {

--- a/Server/Services/CreateFormDto.cs
+++ b/Server/Services/CreateFormDto.cs
@@ -8,6 +8,9 @@ namespace DynamicFormsApp.Server.Services
         public string Name { get; set; }
         public List<FormField> Fields { get; set; }
         public bool RequireLogin { get; set; } = true;
+        public bool NotifyOnResponse { get; set; } = false;
+        public string? NotificationEmail { get; set; }
+        public bool IsActive { get; set; } = true;
         public string? CreatedBy { get; set; }
     }
 }

--- a/Server/Services/CreateFormDto.cs
+++ b/Server/Services/CreateFormDto.cs
@@ -6,6 +6,7 @@ namespace DynamicFormsApp.Server.Services
     public class CreateFormDto
     {
         public string Name { get; set; }
+        public string? Description { get; set; }
         public List<FormField> Fields { get; set; }
         public bool RequireLogin { get; set; } = true;
         public bool NotifyOnResponse { get; set; } = false;

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -198,6 +198,40 @@ namespace DynamicFormsApp.Server.Services
             return results;
         }
 
+        public async Task<Dictionary<string, object>> GetResponseAsync(int formId, int responseId)
+        {
+            var form = await _db.Forms.FindAsync(formId)
+                       ?? throw new InvalidOperationException("Form not found");
+            var rawName = SanitizeKey(form.Name);
+            var tableName = $"Form_{formId}_{rawName}";
+
+            using var conn = _db.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT * FROM [{tableName}] WHERE ResponseId=@id;";
+            var param = cmd.CreateParameter();
+            param.ParameterName = "@id";
+            param.Value = responseId;
+            cmd.Parameters.Add(param);
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            if (!await reader.ReadAsync())
+            {
+                throw new InvalidOperationException("Response not found");
+            }
+
+            var row = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < reader.FieldCount; i++)
+            {
+                var name = reader.GetName(i);
+                var val = await reader.IsDBNullAsync(i) ? null : reader.GetValue(i);
+                row[name] = val!;
+            }
+            return row;
+        }
+
         private string MapToSqlType(string fieldType) => fieldType switch
         {
             "number" => "FLOAT",

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -24,13 +24,16 @@ namespace DynamicFormsApp.Server.Services
         private string SanitizeKey(string raw) =>
             Regex.Replace(raw, @"[^\w]", "_");
 
-        public async Task<int> CreateFormAsync(string formName, List<FormField> fields, string createdBy, bool requireLogin)
+        public async Task<int> CreateFormAsync(string formName, List<FormField> fields, string createdBy, bool requireLogin, bool notifyOnResponse, string? notificationEmail, bool isActive)
         {
             var form = new Form
             {
                 Name = formName,
                 CreatedBy = createdBy,
                 RequireLogin = requireLogin,
+                NotifyOnResponse = notifyOnResponse,
+                NotificationEmail = notificationEmail,
+                IsActive = isActive,
                 Fields = fields.Select(f => new FormField
                 {
                     Key = SanitizeKey(f.Key),
@@ -70,7 +73,7 @@ namespace DynamicFormsApp.Server.Services
                 ?? throw new InvalidOperationException("Form not found");
         }
 
-        public async Task StoreResponseAsync(int formId, Dictionary<string, object> values)
+        public async Task<Form> StoreResponseAsync(int formId, Dictionary<string, object> values)
         {
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
@@ -116,20 +119,49 @@ namespace DynamicFormsApp.Server.Services
 
             sqlParams.Add(new SqlParameter("@p_created", DateTime.UtcNow));
             await _db.Database.ExecuteSqlRawAsync(sql, sqlParams.ToArray());
+
+            return form;
+        }
+
+        public async Task DeactivateFormAsync(int formId, string user)
+        {
+            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId && f.CreatedBy == user);
+            if (form == null)
+            {
+                throw new InvalidOperationException("Form not found");
+            }
+
+            form.IsActive = false;
+            await _db.SaveChangesAsync();
         }
 
         public async Task<List<Form>> GetAllFormsAsync()
         {
             return await _db.Forms
                 .Include(f => f.Fields)
+                .Where(f => f.IsActive)
                 .ToListAsync();
+        }
+
+        public async Task<List<Form>> SearchFormsAsync(bool includePrivate)
+        {
+            var query = _db.Forms
+                .Include(f => f.Fields)
+                .Where(f => f.IsActive);
+
+            if (!includePrivate)
+            {
+                query = query.Where(f => !f.RequireLogin);
+            }
+
+            return await query.ToListAsync();
         }
 
         public async Task<List<Form>> GetFormsByUserAsync(string user)
         {
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.CreatedBy == user)
+                .Where(f => f.CreatedBy == user && f.IsActive)
                 .ToListAsync();
         }
 

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -24,6 +24,21 @@ namespace DynamicFormsApp.Server.Services
         private string SanitizeKey(string raw) =>
             Regex.Replace(raw, @"[^\w]", "_");
 
+        private string GetUniqueKey(string rawKey, HashSet<string> existing)
+        {
+            var baseKey = SanitizeKey(rawKey);
+            var unique = baseKey;
+            int suffix = 1;
+            while (existing.Contains(unique))
+            {
+                unique = $"{baseKey}_{suffix}";
+                suffix++;
+            }
+            existing.Add(unique);
+            return unique;
+        }
+
+
         public async Task<int> CreateFormAsync(string formName, string? description, List<FormField> fields, string createdBy, bool requireLogin, bool notifyOnResponse, string? notificationEmail, bool isActive)
         {
             var form = new Form
@@ -35,17 +50,22 @@ namespace DynamicFormsApp.Server.Services
                 NotifyOnResponse = notifyOnResponse,
                 NotificationEmail = notificationEmail,
                 IsActive = isActive,
-                Fields = fields.Select(f => new FormField
-                {
-                    Key = SanitizeKey(f.Key),
-                    Label = f.Label,
-                    FieldType = f.FieldType,
-                    IsRequired = f.IsRequired,
-                    OptionsJson = f.OptionsJson,
-                    Row = f.Row,
-                    Column = f.Column
-                }).ToList()
+                Fields = new List<FormField>()
             };
+            var keySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var fld in fields)
+            {
+                form.Fields.Add(new FormField
+                {
+                    Key = GetUniqueKey(fld.Key, keySet),
+                    Label = fld.Label,
+                    FieldType = fld.FieldType,
+                    IsRequired = fld.IsRequired,
+                    OptionsJson = fld.OptionsJson,
+                    Row = fld.Row,
+                    Column = fld.Column
+                });
+            }
             _db.Forms.Add(form);
             await _db.SaveChangesAsync();
 

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -24,11 +24,12 @@ namespace DynamicFormsApp.Server.Services
         private string SanitizeKey(string raw) =>
             Regex.Replace(raw, @"[^\w]", "_");
 
-        public async Task<int> CreateFormAsync(string formName, List<FormField> fields, string createdBy, bool requireLogin, bool notifyOnResponse, string? notificationEmail, bool isActive)
+        public async Task<int> CreateFormAsync(string formName, string? description, List<FormField> fields, string createdBy, bool requireLogin, bool notifyOnResponse, string? notificationEmail, bool isActive)
         {
             var form = new Form
             {
                 Name = formName,
+                Description = description,
                 CreatedBy = createdBy,
                 RequireLogin = requireLogin,
                 NotifyOnResponse = notifyOnResponse,

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -55,6 +55,10 @@ namespace DynamicFormsApp.Server.Services
                 $"CREATE TABLE [{tableName}] (" +
                 "ResponseId INT IDENTITY(1,1) PRIMARY KEY, " +
                 "CreatedAt DATETIME2 NOT NULL");
+            if (requireLogin)
+            {
+                sb.Append(", [ResponderName] NVARCHAR(255) NULL");
+            }
 
             foreach (var fld in form.Fields)
             {
@@ -74,7 +78,7 @@ namespace DynamicFormsApp.Server.Services
                 ?? throw new InvalidOperationException("Form not found");
         }
 
-        public async Task<Form> StoreResponseAsync(int formId, Dictionary<string, object> values)
+        public async Task<Form> StoreResponseAsync(int formId, Dictionary<string, object> values, string? responderName = null)
         {
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
@@ -85,6 +89,11 @@ namespace DynamicFormsApp.Server.Services
             var paramNames = string.Join(", ",
                 values.Keys.Select((k, i) => $"@p{i}")
                            .Concat(new[] { "@p_created" }));
+            if (form.RequireLogin)
+            {
+                cols += ", ResponderName";
+                paramNames += ", @p_responder";
+            }
 
             var sql = $"INSERT INTO [{tableName}] ({cols}) VALUES ({paramNames});";
 
@@ -119,6 +128,10 @@ namespace DynamicFormsApp.Server.Services
             }
 
             sqlParams.Add(new SqlParameter("@p_created", DateTime.UtcNow));
+            if (form.RequireLogin)
+            {
+                sqlParams.Add(new SqlParameter("@p_responder", (object?)responderName ?? DBNull.Value));
+            }
             await _db.Database.ExecuteSqlRawAsync(sql, sqlParams.ToArray());
 
             return form;

--- a/Server/Services/EmailService.cs
+++ b/Server/Services/EmailService.cs
@@ -49,5 +49,28 @@ namespace DynamicFormsApp.Server.Services
             };
             await client.SendMailAsync(mail);
         }
+
+        public async Task SendFormResponseNotification(string toEmail, string formName, int formId)
+        {
+            var baseUrl = _configuration["AppBaseUrl"]?.TrimEnd('/') ?? string.Empty;
+            var responsesLink = $"{baseUrl}/forms/{formId}/responses";
+
+            var mail = new MailMessage
+            {
+                From = new MailAddress("NDABugReport@ntnanderson.com"),
+                Subject = $"Your form '{formName}' received a new response",
+                Body = $"A new response has been submitted for your form '<b>{formName}</b>'.<br/>" +
+                       $"<a href='{responsesLink}'>View responses</a>.",
+                IsBodyHtml = true
+            };
+
+            mail.To.Add(toEmail);
+
+            using var client = new SmtpClient(_configuration["Email:IP"])
+            {
+                Port = int.Parse(_configuration["Email:Port"]!)
+            };
+            await client.SendMailAsync(mail);
+        }
     }
 }

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -14,4 +14,5 @@
     }
   },
   "AllowedHosts": "*"
+  ,"AppBaseUrl": "https://example.com"
 }

--- a/Server/wwwroot/css/form-builder.css
+++ b/Server/wwwroot/css/form-builder.css
@@ -41,6 +41,22 @@
     .drag-handle:active {
         cursor: grabbing;
     }
+
+/* ↕️ Row move handle */
+.row-handle {
+    cursor: grab;
+    position: absolute;
+    left: -1rem;
+    top: 0.25rem;
+}
+
+    .row-handle:active {
+        cursor: grabbing;
+    }
+
+.row-wrapper {
+    position: relative;
+}
 /* ➕ Row drop zones */
 .row-dropzone {
     height: 20px;
@@ -81,5 +97,8 @@ body[data-bs-theme="dark"] .row-dropzone {
 }
 body[data-bs-theme="dark"] .row-dropzone::after {
     background: #343a40;
+    color: #adb5bd;
+}
+body[data-bs-theme="dark"] .row-handle {
     color: #adb5bd;
 }

--- a/Server/wwwroot/css/form-builder.css
+++ b/Server/wwwroot/css/form-builder.css
@@ -3,9 +3,11 @@
     cursor: grab;
     border: 1px dashed #ced4da;
     background-color: #f8f9fa;
-    padding: 0.75rem;
+    padding: 0.5rem 0.75rem;
     transition: all 0.2s ease;
     user-select: none;
+    display: inline-flex;
+    align-items: center;
 }
 
     .draggable-field:active {

--- a/Server/wwwroot/css/form-builder.css
+++ b/Server/wwwroot/css/form-builder.css
@@ -8,6 +8,7 @@
     user-select: none;
     display: inline-flex;
     align-items: center;
+    flex: 0 0 calc(50% - 0.5rem);
 }
 
     .draggable-field:active {

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -28,3 +28,15 @@ window.initListSortable = (selector, dotnetHelper) => {
         onEnd: evt => dotnetHelper.invokeMethodAsync('OnFieldReorder', evt.oldIndex, evt.newIndex)
     });
 };
+
+window.initRowSortable = (selector, dotnetHelper) => {
+    const container = document.querySelector(selector);
+    if (!container || container.dataset.rowSortableInit === 'true') return;
+    container.dataset.rowSortableInit = 'true';
+    new Sortable(container, {
+        animation: 150,
+        handle: '.row-handle',
+        draggable: '.row-wrapper',
+        onEnd: evt => dotnetHelper.invokeMethodAsync('OnRowReorder', evt.oldIndex, evt.newIndex)
+    });
+};

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -1,4 +1,4 @@
-window.initSortable = (selector, dotnetHelper) => {
+globalThis.initSortable = (selector, dotnetHelper) => {
     const container = document.querySelector(selector);
     if (!container) return;
 
@@ -18,7 +18,7 @@ window.initSortable = (selector, dotnetHelper) => {
     });
 };
 
-window.initListSortable = (selector, dotnetHelper) => {
+globalThis.initListSortable = (selector, dotnetHelper) => {
     const container = document.querySelector(selector);
     if (!container || container.dataset.sortableInit === 'true') return;
     container.dataset.sortableInit = 'true';
@@ -29,7 +29,7 @@ window.initListSortable = (selector, dotnetHelper) => {
     });
 };
 
-window.initRowSortable = (selector, dotnetHelper) => {
+globalThis.initRowSortable = (selector, dotnetHelper) => {
     const container = document.querySelector(selector);
     if (!container || container.dataset.rowSortableInit === 'true') return;
     container.dataset.rowSortableInit = 'true';

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -17,3 +17,14 @@ window.initSortable = (selector, dotnetHelper) => {
         });
     });
 };
+
+window.initListSortable = (selector, dotnetHelper) => {
+    const container = document.querySelector(selector);
+    if (!container || container.dataset.sortableInit === 'true') return;
+    container.dataset.sortableInit = 'true';
+    new Sortable(container, {
+        animation: 150,
+        handle: '.move-handle',
+        onEnd: evt => dotnetHelper.invokeMethodAsync('OnFieldReorder', evt.oldIndex, evt.newIndex)
+    });
+};


### PR DESCRIPTION
## Summary
- display total forms created on the home page
- include a link and friendlier subject in response notification emails
- add `AppBaseUrl` app setting for email links
- allow form owners to soft delete forms via new `IsActive` flag
- confirm delete action and add public form search page
- improved delete UI with Radzen dialog and notification
- only count active forms when displaying the total

## Testing
- `dotnet test DynamicFormsApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685445bda4bc83298199dc85af821ea4