### PR TITLE
Allow row reordering in form builder

### DIFF
--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -10,11 +10,11 @@
                 <input class="form-control form-control-sm" placeholder="Field label" @bind="Field.Label" />
             </div>
             <div class="d-flex gap-2">
-                <button class="btn btn-sm btn-outline-secondary" @onclick="() => OnDuplicate.InvokeAsync(Field)">
-                    <i class="bi bi-copy"></i>
+                <button class="btn btn-sm btn-outline-secondary" title="Duplicate" @onclick="() => OnDuplicate.InvokeAsync(Field)">
+                    <i class="bi bi-files"></i>
                 </button>
-                <button class="btn btn-sm btn-outline-danger" @onclick="() => OnRemove.InvokeAsync(Field)">
-                    <i class="bi bi-trash"></i>
+                <button class="btn btn-sm btn-outline-danger" title="Remove" @onclick="() => OnRemove.InvokeAsync(Field)">
+                    <i class="bi bi-x-lg"></i>
                 </button>
             </div>
         </div>

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -1,5 +1,9 @@
 ﻿@using DynamicFormsApp.Shared
 
+@if (!string.IsNullOrWhiteSpace(FormName))
+{
+    <h4 class="mb-2">@FormName</h4>
+}
 <h5 class="text-muted">Live Preview</h5>
 
 @foreach (var row in Rows)
@@ -122,4 +126,5 @@
 
 @code {
     [Parameter] public List<DesignerRow> Rows { get; set; } = new();
+    [Parameter] public string FormName { get; set; } = string.Empty;
 }

--- a/Client/Layout/MainLayout.razor
+++ b/Client/Layout/MainLayout.razor
@@ -54,6 +54,7 @@
             <RadzenPanelMenuItem Text="Home" Path="" Icon="Home"/>
             <RadzenPanelMenuItem Text="Create Form" Path="forms/new" Icon="add_box" />
             <RadzenPanelMenuItem Text="My Forms" Path="myforms" Icon="list" />
+            <RadzenPanelMenuItem Text="Search Forms" Path="forms/search" Icon="search" />
         </RadzenPanelMenu>
 
         <!-- Footer section of the sidebar -->

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -145,7 +145,7 @@
             }
 
             objRef = DotNetObjectReference.Create(this);
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
             await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef);
         }
     }
@@ -164,7 +164,7 @@
         fields.Add(new DesignerField());
         await InvokeAsync(StateHasChanged);
         if (sortableModule == null)
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 
@@ -173,7 +173,7 @@
         fields.Remove(field);
         await InvokeAsync(StateHasChanged);
         if (sortableModule == null)
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 
@@ -191,7 +191,7 @@
         fields.Insert(index + 1, copy);
         await InvokeAsync(StateHasChanged);
         if (sortableModule == null)
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -1,9 +1,15 @@
 ﻿@page "/razer"
 @using System.Net.Http.Json
 @using System.Text.Json
+@using DynamicFormsApp.Shared.Models
+@using Microsoft.JSInterop
+@inject IUserService UserService
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
+@inject IJSRuntime JS
+@implements IDisposable
+@inject IJSRuntime JS
 
 <h2 class="mb-4">Form Builder</h2>
 
@@ -14,24 +20,51 @@
            placeholder="Enter your form title"
            @bind="formName" />
 </div>
+<div class="mb-4">
+    <label class="form-label">Description</label>
+    <textarea class="form-control" placeholder="Enter a description" @bind="formDescription"></textarea>
+</div>
 
 <div class="form-check form-switch mb-4">
     <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" />
     <label class="form-check-label" for="loginToggle">Require login to access form</label>
 </div>
-
-@foreach (var field in fields)
+<div class="form-check form-switch mb-4">
+    <input class="form-check-input" type="checkbox" id="notifyToggle" @bind="notifyOnResponse" />
+    <label class="form-check-label" for="notifyToggle">Email on new response</label>
+</div>
+@if (notifyOnResponse)
 {
-    <div class="card mb-3 shadow-sm border-start border-5 border-primary">
+    <div class="mb-3">
+        <label class="form-label">Notification Email</label>
+        <input class="form-control" placeholder="@currentUser?.Email" @bind="notificationEmail" />
+    </div>
+}
+
+<div id="simple-fields">
+@for (int index = 0; index < fields.Count; index++)
+{
+    var field = fields[index];
+    <div class="card mb-3 shadow-sm border-start border-5 border-primary" data-idx="@index">
         <div class="card-body">
-            <div class="d-flex justify-content-between">
-                <input type="text"
-                       class="form-control form-control-sm mb-2"
-                       placeholder="Question/Label"
-                       @bind="field.Label" />
-                <button class="btn btn-outline-danger btn-sm" @onclick="() => RemoveField(field)">
-                    <i class="bi bi-trash"></i>
-                </button>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <div class="d-flex align-items-center gap-2">
+                    <button type="button" class="btn btn-sm btn-outline-secondary move-handle">
+                        <i class="bi bi-grip-vertical"></i>
+                    </button>
+                    <input type="text"
+                           class="form-control form-control-sm"
+                           placeholder="Question/Label"
+                           @bind="field.Label" />
+                </div>
+                <div class="btn-group">
+                    <button class="btn btn-sm btn-outline-secondary" title="Duplicate" @onclick="() => DuplicateField(index)">
+                        <i class="bi bi-files"></i>
+                    </button>
+                    <button class="btn btn-sm btn-outline-danger" title="Remove" @onclick="() => RemoveField(field)">
+                        <i class="bi bi-x-lg"></i>
+                    </button>
+                </div>
             </div>
 
             <div class="row g-2 align-items-center">
@@ -58,7 +91,7 @@
                 </div>
                 <div class="col-md-4">
                     <input type="text" class="form-control"
-                           placeholder="Options (comma-separated)"
+                           placeholder="Option1, Option2, ..."
                            @bind="field.Options" />
                 </div>
             </div>
@@ -70,6 +103,7 @@
         </div>
     </div>
 }
+</div>
 
 <div class="d-grid mb-3">
     <button class="btn btn-outline-secondary" @onclick="AddField">
@@ -85,8 +119,14 @@
 
 @code {
     private string formName = string.Empty;
+    private string formDescription = string.Empty;
     private List<DesignerField> fields = new();
     private bool requireLogin = true;
+    private bool notifyOnResponse = false;
+    private string notificationEmail = string.Empty;
+    private UserModel? currentUser;
+    private DotNetObjectReference<FormDesigner>? objRef;
+    private IJSObjectReference? sortableModule;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -98,6 +138,15 @@
                 var ret = Uri.EscapeDataString(Navigation.ToBaseRelativePath(Navigation.Uri));
                 Navigation.NavigateTo($"login?returnUrl={ret}", true);
             }
+            else
+            {
+                currentUser = await UserService.GetUserData(user);
+                notificationEmail = currentUser?.Email ?? string.Empty;
+            }
+
+            objRef = DotNetObjectReference.Create(this);
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+            await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef);
         }
     }
 
@@ -110,15 +159,100 @@
         public bool IsRequired { get; set; }
     }
 
-    void AddField() => fields.Add(new DesignerField());
-    void RemoveField(DesignerField field) => fields.Remove(field);
+    async Task AddField()
+    {
+        fields.Add(new DesignerField());
+        await InvokeAsync(StateHasChanged);
+        if (sortableModule == null)
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+    }
+
+    async Task RemoveField(DesignerField field)
+    {
+        fields.Remove(field);
+        await InvokeAsync(StateHasChanged);
+        if (sortableModule == null)
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+    }
+
+    async Task DuplicateField(int index)
+    {
+        var src = fields[index];
+        var copy = new DesignerField
+        {
+            Key = src.Key + "_copy",
+            Label = src.Label,
+            FieldType = src.FieldType,
+            Options = src.Options,
+            IsRequired = src.IsRequired
+        };
+        fields.Insert(index + 1, copy);
+        await InvokeAsync(StateHasChanged);
+        if (sortableModule == null)
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
+    }
+
+    [JSInvokable]
+    public void OnFieldReorder(int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 || oldIndex >= fields.Count || newIndex >= fields.Count)
+            return;
+        var item = fields[oldIndex];
+        fields.RemoveAt(oldIndex);
+        fields.Insert(newIndex, item);
+        StateHasChanged();
+    }
 
     async Task HandleSubmit()
     {
+        if (string.IsNullOrWhiteSpace(formName))
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Form name required",
+                Detail = "Please enter a form name before creating."
+            });
+            return;
+        }
+
+        foreach (var f in fields)
+        {
+            if (string.IsNullOrWhiteSpace(f.Key) || string.IsNullOrWhiteSpace(f.Label))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Field details missing",
+                    Detail = "Each field needs a key and a label."
+                });
+                return;
+            }
+
+            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") &&
+                f.Options.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Length == 0)
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options required",
+                    Detail = $"Add at least one option for '{f.Label}'."
+                });
+                return;
+            }
+        }
+
         var payload = new
         {
             Name = formName,
+            Description = formDescription,
             RequireLogin = requireLogin,
+            NotifyOnResponse = notifyOnResponse,
+            NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
+            IsActive = true,
             Fields = fields.Select(f => new
             {
                 Key = f.Key,
@@ -142,7 +276,18 @@
         }
         else
         {
-            // TODO: Error alert
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Error,
+                Summary = "Error",
+                Detail = "Failed to create form."
+            });
         }
+    }
+
+    public void Dispose()
+    {
+        objRef?.Dispose();
+        _ = sortableModule?.DisposeAsync();
     }
 }

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -145,7 +145,7 @@
             }
 
             objRef = DotNetObjectReference.Create(this);
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
             await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef);
         }
     }
@@ -164,7 +164,7 @@
         fields.Add(new DesignerField());
         await InvokeAsync(StateHasChanged);
         if (sortableModule == null)
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 
@@ -173,7 +173,7 @@
         fields.Remove(field);
         await InvokeAsync(StateHasChanged);
         if (sortableModule == null)
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 
@@ -191,7 +191,7 @@
         fields.Insert(index + 1, copy);
         await InvokeAsync(StateHasChanged);
         if (sortableModule == null)
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -145,7 +145,7 @@
             }
 
             objRef = DotNetObjectReference.Create(this);
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
             await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef);
         }
     }
@@ -164,7 +164,7 @@
         fields.Add(new DesignerField());
         await InvokeAsync(StateHasChanged);
         if (sortableModule == null)
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 
@@ -173,7 +173,7 @@
         fields.Remove(field);
         await InvokeAsync(StateHasChanged);
         if (sortableModule == null)
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 
@@ -191,7 +191,7 @@
         fields.Insert(index + 1, copy);
         await InvokeAsync(StateHasChanged);
         if (sortableModule == null)
-            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+            sortableModule = await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initListSortable", "#simple-fields", objRef!);
     }
 

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -2,12 +2,14 @@
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using System.Text.Json
+@using System.Linq
 @using DynamicFormsApp.Shared.Models
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
 
 <h3>@(form?.Name ?? "Loading…")</h3>
+<p class="text-muted">@form?.Description</p>
 
 @if (form == null)
 {
@@ -30,7 +32,13 @@ else
             {
                 <div class="col-md-@(12 / (rowGroup.Count() == 0 ? 1 : rowGroup.Count()))">
                     <div class="mb-3">
-                        <label class="form-label">@fld.Label</label>
+                        <label class="form-label fw-semibold">
+                            @fld.Label
+                            @if (fld.IsRequired)
+                            {
+                                <span class="text-danger"> *</span>
+                            }
+                        </label>
 
                 @switch (fld.FieldType)
                 {
@@ -277,8 +285,33 @@ else
 
     private async Task SubmitResponse()
     {
+        foreach (var fld in form.Fields)
+        {
+            if (!fld.IsRequired)
+                continue;
+
+            if (!responseData.TryGetValue(fld.Key, out var val) || IsEmpty(val))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Missing answer",
+                    Detail = $"Please fill out '{fld.Label}'."
+                });
+                return;
+            }
+        }
+
         await Http.PostAsJsonAsync($"api/forms/{FormId}/responses", responseData);
         Navigation.NavigateTo($"/forms/{FormId}/responses");
+    }
+
+    bool IsEmpty(object value)
+    {
+        if (value == null) return true;
+        if (value is string s) return string.IsNullOrWhiteSpace(s);
+        if (value is IEnumerable<string> list) return !list.Any();
+        return false;
     }
 
     private class FileUploadResult

--- a/Client/Pages/DynamicForms/FormResponses.razor
+++ b/Client/Pages/DynamicForms/FormResponses.razor
@@ -9,6 +9,7 @@
 
 <div class="container mt-4">
     <h2 class="mb-4">📄 Responses: <span class="text-primary">@form?.Name</span></h2>
+    <p class="text-muted">@form?.Description</p>
 
     @if (form == null || responses == null)
     {
@@ -30,8 +31,9 @@
                     <tr>
                         @foreach (var col in columns)
                         {
-                            <th scope="col">@col</th>
+                            <th scope="col">@(col == "ResponderName" ? "Submitted By" : col)</th>
                         }
+                        <th scope="col"></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -70,6 +72,9 @@
                                     }
                                 </td>
                             }
+                            <td>
+                                <a class="btn btn-sm btn-outline-primary" href="@($"/forms/{FormId}/responses/{row["ResponseId"]}")">View</a>
+                            </td>
                         </tr>
                     }
                 </tbody>
@@ -101,7 +106,15 @@
             responses = await Http.GetFromJsonAsync<List<Dictionary<string, object>>>($"api/forms/{FormId}/responses");
 
             var fieldKeys = form.Fields.Select(f => f.Key);
-            columns = new[] { "ResponseId", "CreatedAt" }.Concat(fieldKeys).ToArray();
+            columns = new[] { "ResponseId", "CreatedAt" }
+                .Concat(fieldKeys)
+                .ToArray();
+            if (form.RequireLogin)
+            {
+                columns = columns
+                    .Concat(new[] { "ResponderName" })
+                    .ToArray();
+            }
 
             StateHasChanged();
         }

--- a/Client/Pages/DynamicForms/FormSummary.razor
+++ b/Client/Pages/DynamicForms/FormSummary.razor
@@ -7,6 +7,7 @@
 @inject CookieHelper CookieHelper
 
 <h3>Summary for @form?.Name</h3>
+<p class="text-muted">@form?.Description</p>
 
 @if (form == null || responses == null)
 {

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -141,8 +141,8 @@ else
         if (!isPreviewMode && (firstRender || lastPreviewMode))
         {
             objRef ??= DotNetObjectReference.Create(this);
-            sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
-            dragdropModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/dragdrop-wrapper.js");
+            sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+            dragdropModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/dragdrop-wrapper.js");
             await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef);
             await dragdropModule.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
             await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef);
@@ -190,7 +190,7 @@ else
         rows.RemoveAt(oldIndex);
         rows.Insert(newIndex, row);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -199,7 +199,7 @@ else
     {
         rows.Add(new DesignerRow());
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -218,7 +218,7 @@ else
         }
         rows[row].Fields.Add(new DesignerField());
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -227,7 +227,7 @@ else
     {
         rows[row].Fields.Remove(field);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -249,7 +249,7 @@ else
         var list = rows[row].Fields;
         list.Insert(list.IndexOf(field) + 1, copy);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -281,7 +281,7 @@ else
             list.Insert(colIndex, field);
 
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -296,7 +296,7 @@ else
         row.Fields.Add(new DesignerField { FieldType = fieldType });
         rows.Insert(insertIndex, row);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -141,8 +141,8 @@ else
         if (!isPreviewMode && (firstRender || lastPreviewMode))
         {
             objRef ??= DotNetObjectReference.Create(this);
-            sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
-            dragdropModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/dragdrop-wrapper.js");
+            sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+            dragdropModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/dragdrop-wrapper.js");
             await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef);
             await dragdropModule.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
             await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef);
@@ -190,7 +190,7 @@ else
         rows.RemoveAt(oldIndex);
         rows.Insert(newIndex, row);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -199,7 +199,7 @@ else
     {
         rows.Add(new DesignerRow());
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -218,7 +218,7 @@ else
         }
         rows[row].Fields.Add(new DesignerField());
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -227,7 +227,7 @@ else
     {
         rows[row].Fields.Remove(field);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -249,7 +249,7 @@ else
         var list = rows[row].Fields;
         list.Insert(list.IndexOf(field) + 1, copy);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -281,7 +281,7 @@ else
             list.Insert(colIndex, field);
 
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -296,7 +296,7 @@ else
         row.Fields.Add(new DesignerField { FieldType = fieldType });
         rows.Insert(insertIndex, row);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/_content/DynamicFormsApp.Server/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -3,14 +3,17 @@
 @using System.Text.Json
 @using DynamicFormsApp.Client.Components
 @using DynamicFormsApp.Shared
+@using DynamicFormsApp.Shared.Models
 @inject IJSRuntime JS
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
+@inject IUserService UserService
 
 @implements IDisposable
 
-<h2 class="mb-4">Form Builder</h2>
+<h2 class="mb-2">Form Builder</h2>
+<p class="text-muted">Drag fields to reorder or move them between rows. Each row can have up to four columns.</p>
 
 <div class="form-check form-switch mb-4">
     <input class="form-check-input" type="checkbox" id="previewToggle" @bind="isPreviewMode" />
@@ -21,18 +24,33 @@
     <label class="form-label">Form Name</label>
     <input class="form-control form-control-lg" placeholder="Enter your form title" @bind="formName" />
 </div>
+<div class="mb-4">
+    <label class="form-label">Description</label>
+    <textarea class="form-control" placeholder="Enter a description" @bind="formDescription"></textarea>
+</div>
 
 <div class="form-check form-switch mb-4">
     <input class="form-check-input" type="checkbox" id="loginToggle" @bind="requireLogin" />
     <label class="form-check-label" for="loginToggle">Require login to access form</label>
 </div>
+<div class="form-check form-switch mb-4">
+    <input class="form-check-input" type="checkbox" id="notifyToggle" @bind="notifyOnResponse" />
+    <label class="form-check-label" for="notifyToggle">Email on new response</label>
+</div>
+@if (notifyOnResponse)
+{
+    <div class="mb-3">
+        <label class="form-label">Notification Email</label>
+        <input class="form-control" placeholder="@currentUser?.Email" @bind="notificationEmail" />
+    </div>
+}
 
 @if (!isPreviewMode)
 {
     <div class="row">
-        <div class="col-md-3">
+        <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
             <h5 class="mb-3">Toolbox</h5>
-            <div class="d-flex flex-column gap-2">
+            <div class="d-flex flex-wrap gap-2">
                 <div class="draggable-field" draggable="true" data-type="text"><span class="material-icons me-1">short_text</span> Short Answer</div>
                 <div class="draggable-field" draggable="true" data-type="textarea"><span class="material-icons me-1">notes</span> Paragraph</div>
                 <div class="draggable-field" draggable="true" data-type="radio"><span class="material-icons me-1">radio_button_checked</span> Multiple Choice</div>
@@ -55,17 +73,20 @@
                 {
                     var rowIndex = r;
                     <div class="row-dropzone" data-insert="@rowIndex"></div>
-                    <div class="row g-3 mb-3 designer-row" data-row="@rowIndex">
+                    <div class="row-wrapper position-relative mb-3" data-row="@rowIndex">
+                        <span class="row-handle text-muted"><i class="bi bi-grip-vertical"></i></span>
+                        <div class="row g-3 designer-row" data-row="@rowIndex">
                         @for (int i = 0; i < rows[rowIndex].Fields.Count; i++)
                         {
                             <div class="col-md-@(12 / (rows[rowIndex].Fields.Count == 0 ? 1 : rows[rowIndex].Fields.Count))" data-id="@i">
                                 <FieldEditor Field="rows[rowIndex].Fields[i]"
-                                             OnRemove="f => RemoveField(rowIndex, f)"
-                                             OnDuplicate="f => DuplicateField(rowIndex, f)" />
+                                             OnRemove="async f => await RemoveField(rowIndex, f)"
+                                             OnDuplicate="async f => await DuplicateField(rowIndex, f)" />
                             </div>
                         }
                         <div class="col-12">
                             <button class="btn btn-sm btn-outline-secondary" @onclick="() => AddField(rowIndex)">+ Add Column</button>
+                        </div>
                         </div>
                     </div>
                 }
@@ -83,16 +104,23 @@
 else
 {
     <div class="card p-3 shadow-sm">
-        <LivePreview Rows="rows" />
+        <LivePreview Rows="rows" FormName="@formName" />
     </div>
 }
 
 @code {
     private string formName = string.Empty;
+    private string formDescription = string.Empty;
     private List<DesignerRow> rows = new() { new DesignerRow() };
     private bool isPreviewMode = false;
     private bool requireLogin = true;
+    private bool notifyOnResponse = false;
+    private string notificationEmail = string.Empty;
+    private UserModel? currentUser;
     private DotNetObjectReference<Index>? objRef;
+    private IJSObjectReference? sortableModule;
+    private IJSObjectReference? dragdropModule;
+    private bool lastPreviewMode;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -106,14 +134,25 @@ else
                 return;
             }
 
-            objRef ??= DotNetObjectReference.Create(this);
-            await JS.InvokeVoidAsync("initSortable", "#fields-container", objRef);
-            await JS.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
+            currentUser = await UserService.GetUserData(user);
+            notificationEmail = currentUser?.Email ?? string.Empty;
         }
+
+        if (!isPreviewMode && (firstRender || lastPreviewMode))
+        {
+            objRef ??= DotNetObjectReference.Create(this);
+            sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+            dragdropModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/dragdrop-wrapper.js");
+            await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef);
+            await dragdropModule.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
+            await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef);
+        }
+
+        lastPreviewMode = isPreviewMode;
     }
 
     [JSInvokable]
-    public void OnSortUpdate(int fromRow, int oldIndex, int toRow, int newIndex)
+    public async Task OnSortUpdate(int fromRow, int oldIndex, int toRow, int newIndex)
     {
         if (fromRow < 0 || fromRow >= rows.Count || toRow < 0 || toRow >= rows.Count)
             return;
@@ -124,19 +163,76 @@ else
         if (oldIndex < 0 || oldIndex >= source.Count || newIndex < 0 || newIndex > dest.Count)
             return;
 
+        if (fromRow != toRow && dest.Count >= 4)
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Column limit reached",
+                Detail = "A row can contain at most four columns."
+            });
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
         var moved = source[oldIndex];
         source.RemoveAt(oldIndex);
         dest.Insert(newIndex, moved);
         StateHasChanged();
     }
 
-    void AddRow() => rows.Add(new DesignerRow());
+    [JSInvokable]
+    public async Task OnRowReorder(int oldIndex, int newIndex)
+    {
+        if (oldIndex == newIndex || oldIndex < 0 || newIndex < 0 || oldIndex >= rows.Count || newIndex >= rows.Count)
+            return;
+        var row = rows[oldIndex];
+        rows.RemoveAt(oldIndex);
+        rows.Insert(newIndex, row);
+        await InvokeAsync(StateHasChanged);
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
+    }
 
-    void AddField(int row) => rows[row].Fields.Add(new DesignerField());
+    async Task AddRow()
+    {
+        rows.Add(new DesignerRow());
+        await InvokeAsync(StateHasChanged);
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
+    }
 
-    void RemoveField(int row, DesignerField field) => rows[row].Fields.Remove(field);
+    async Task AddField(int row)
+    {
+        if (rows[row].Fields.Count >= 4)
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Column limit reached",
+                Detail = "A row can contain at most four columns."
+            });
+            return;
+        }
+        rows[row].Fields.Add(new DesignerField());
+        await InvokeAsync(StateHasChanged);
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
+    }
 
-    void DuplicateField(int row, DesignerField field)
+    async Task RemoveField(int row, DesignerField field)
+    {
+        rows[row].Fields.Remove(field);
+        await InvokeAsync(StateHasChanged);
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
+    }
+
+    async Task DuplicateField(int row, DesignerField field)
     {
         var copy = new DesignerField
         {
@@ -152,10 +248,14 @@ else
         };
         var list = rows[row].Fields;
         list.Insert(list.IndexOf(field) + 1, copy);
+        await InvokeAsync(StateHasChanged);
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
 
     [JSInvokable]
-    public void AddFieldFromDrop(string fieldType, int rowIndex, int colIndex)
+    public async Task AddFieldFromDrop(string fieldType, int rowIndex, int colIndex)
     {
         if (rowIndex < 0 || rowIndex >= rows.Count)
             rowIndex = rows.Count - 1;
@@ -163,16 +263,31 @@ else
         var list = rows[rowIndex].Fields;
         var field = new DesignerField { FieldType = fieldType };
 
+        if (list.Count >= 4)
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Column limit reached",
+                Detail = "A row can contain at most four columns."
+            });
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
         if (colIndex < 0 || colIndex > list.Count)
             list.Add(field);
         else
             list.Insert(colIndex, field);
 
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
 
     [JSInvokable]
-    public void AddRowFromDrop(string fieldType, int insertIndex)
+    public async Task AddRowFromDrop(string fieldType, int insertIndex)
     {
         if (insertIndex < 0 || insertIndex > rows.Count)
             insertIndex = rows.Count;
@@ -180,15 +295,58 @@ else
         var row = new DesignerRow();
         row.Fields.Add(new DesignerField { FieldType = fieldType });
         rows.Insert(insertIndex, row);
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+        await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
+        await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
 
     async Task HandleSubmit()
     {
+        if (string.IsNullOrWhiteSpace(formName))
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Form name required",
+                Detail = "Please enter a form name before creating."
+            });
+            return;
+        }
+
+        foreach (var f in rows.SelectMany(r => r.Fields))
+        {
+            if (string.IsNullOrWhiteSpace(f.Key) || string.IsNullOrWhiteSpace(f.Label))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Field details missing",
+                    Detail = "Each field needs a key and a label."
+                });
+                return;
+            }
+
+            if ((f.FieldType == "radio" || f.FieldType == "checkbox" || f.FieldType == "dropdown") && f.OptionItems.Count == 0)
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options required",
+                    Detail = $"Add at least one option for '{f.Label}'."
+                });
+                return;
+            }
+        }
+
         var payload = new
         {
             Name = formName,
+            Description = formDescription,
             RequireLogin = requireLogin,
+            NotifyOnResponse = notifyOnResponse,
+            NotificationEmail = string.IsNullOrWhiteSpace(notificationEmail) ? null : notificationEmail,
+            IsActive = true,
             Fields = rows.SelectMany((row, rIdx) => row.Fields.Select((f, cIdx) => new
             {
                 f.Key,
@@ -217,5 +375,7 @@ else
     public void Dispose()
     {
         objRef?.Dispose();
+        _ = sortableModule?.DisposeAsync();
+        _ = dragdropModule?.DisposeAsync();
     }
 }

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -141,8 +141,8 @@ else
         if (!isPreviewMode && (firstRender || lastPreviewMode))
         {
             objRef ??= DotNetObjectReference.Create(this);
-            sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
-            dragdropModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/dragdrop-wrapper.js");
+            sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
+            dragdropModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/dragdrop-wrapper.js");
             await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef);
             await dragdropModule.InvokeVoidAsync("initFieldDragDrop", "#fields-container", objRef);
             await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef);
@@ -190,7 +190,7 @@ else
         rows.RemoveAt(oldIndex);
         rows.Insert(newIndex, row);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -199,7 +199,7 @@ else
     {
         rows.Add(new DesignerRow());
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -218,7 +218,7 @@ else
         }
         rows[row].Fields.Add(new DesignerField());
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -227,7 +227,7 @@ else
     {
         rows[row].Fields.Remove(field);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -249,7 +249,7 @@ else
         var list = rows[row].Fields;
         list.Insert(list.IndexOf(field) + 1, copy);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -281,7 +281,7 @@ else
             list.Insert(colIndex, field);
 
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }
@@ -296,7 +296,7 @@ else
         row.Fields.Add(new DesignerField { FieldType = fieldType });
         rows.Insert(insertIndex, row);
         await InvokeAsync(StateHasChanged);
-        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "/js/sortable-wrapper.js");
+        sortableModule ??= await JS.InvokeAsync<IJSObjectReference>("import", "./js/sortable-wrapper.js");
         await sortableModule.InvokeVoidAsync("initSortable", "#fields-container", objRef!);
         await sortableModule.InvokeVoidAsync("initRowSortable", "#fields-container", objRef!);
     }

--- a/Client/Pages/DynamicForms/MyForms.razor
+++ b/Client/Pages/DynamicForms/MyForms.razor
@@ -22,6 +22,7 @@ else
             <thead>
                 <tr>
                     <th>Name</th>
+                    <th>Description</th>
                     <th></th>
                 </tr>
             </thead>
@@ -30,10 +31,12 @@ else
                 {
                     <tr>
                         <td>@f.Name</td>
+                        <td>@f.Description</td>
                         <td>
                             <a class="btn btn-sm btn-primary me-2" href="@($"/forms/{f.Id}")">Open</a>
                             <a class="btn btn-sm btn-secondary me-2" href="@($"/forms/{f.Id}/responses")">Responses</a>
-                            <a class="btn btn-sm btn-info" href="@($"/forms/{f.Id}/summary")">Summary</a>
+                            <a class="btn btn-sm btn-info me-2" href="@($"/forms/{f.Id}/summary")">Summary</a>
+                            <button class="btn btn-sm btn-danger" @onclick="() => DeleteForm(f.Id)">Delete</button>
                         </td>
                     </tr>
                 }
@@ -60,5 +63,35 @@ else
             forms = await Http.GetFromJsonAsync<List<Form>>("api/forms/mine");
             StateHasChanged();
         }
+    }
+
+    private async Task DeleteForm(int id)
+    {
+        var item = forms?.FirstOrDefault(f => f.Id == id);
+        if (item == null)
+        {
+            return;
+        }
+
+        bool? confirmed = await DialogService.Confirm(
+            "Are you sure you want to delete this form?",
+            "Delete Form",
+            new ConfirmOptions { OkButtonText = "Yes", CancelButtonText = "No" });
+
+        if (confirmed != true)
+        {
+            return;
+        }
+
+        await Http.DeleteAsync($"api/forms/{id}");
+
+        forms!.Remove(item);
+        NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Success,
+                Summary = "Form Deleted",
+                Detail = item.Name
+            });
+        StateHasChanged();
     }
 }

--- a/Client/Pages/DynamicForms/SearchForms.razor
+++ b/Client/Pages/DynamicForms/SearchForms.razor
@@ -1,0 +1,68 @@
+@page "/forms/search"
+@using System.Net.Http.Json
+@inject HttpClient Http
+@inject NavigationManager Navigation
+@using System.Linq
+@inject CookieHelper CookieHelper
+
+<h3 class="mb-3">Search Forms</h3>
+
+<input class="form-control mb-3" placeholder="Search..." @bind="searchTerm" />
+
+@if (forms == null)
+{
+    <p>Loading...</p>
+}
+else if (!FilteredForms.Any())
+{
+    <p>No matching forms.</p>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var f in FilteredForms)
+                {
+                    <tr>
+                        <td>@f.Name</td>
+                        <td>@f.Description</td>
+                        <td>
+                            <a class="btn btn-sm btn-primary" href="@($"/forms/{f.Id}")">Open</a>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@code {
+    private List<Form>? forms;
+    private string searchTerm = string.Empty;
+
+    private IEnumerable<Form> FilteredForms => string.IsNullOrWhiteSpace(searchTerm)
+        ? forms ?? Enumerable.Empty<Form>()
+        : forms?.Where(f =>
+            (f.Name?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            (f.Description?.Contains(searchTerm, StringComparison.OrdinalIgnoreCase) ?? false))
+            ?? Enumerable.Empty<Form>();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var user = await CookieHelper.LoginStatus();
+            bool includePrivate = !string.IsNullOrEmpty(user);
+            forms = await Http.GetFromJsonAsync<List<Form>>($"api/forms/search?includePrivate={includePrivate}");
+            StateHasChanged();
+        }
+    }
+}

--- a/Client/Pages/DynamicForms/ViewResponse.razor
+++ b/Client/Pages/DynamicForms/ViewResponse.razor
@@ -1,0 +1,129 @@
+@page "/forms/{FormId:int}/responses/{ResponseId:int}"
+@using System.Net.Http.Json
+@using System.Text.Json
+@using DynamicFormsApp.Shared.Models
+@inject HttpClient Http
+@inject NavigationManager Navigation
+@inject CookieHelper CookieHelper
+
+<div class="d-flex justify-content-between align-items-center">
+    <h3 class="mb-0">Response for @form?.Name</h3>
+    @if (!string.IsNullOrEmpty(responderName))
+    {
+        <span class="text-muted">Submitted by @responderName</span>
+    }
+</div>
+<p class="text-muted">@form?.Description</p>
+
+@if (form == null || response == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    @foreach (var rowGroup in form.Fields.OrderBy(f => f.Row ?? 0).ThenBy(f => f.Column ?? 0).GroupBy(f => f.Row ?? 0))
+    {
+        <div class="row g-3 mb-3">
+        @foreach (var fld in rowGroup)
+        {
+            <div class="col-md-@(12 / (rowGroup.Count() == 0 ? 1 : rowGroup.Count()))">
+                <div class="mb-3">
+                    <label class="form-label fw-semibold">@fld.Label</label>
+                    <div class="form-control-plaintext border rounded bg-light p-2">
+                        @DisplayValue(fld)
+                    </div>
+                </div>
+            </div>
+        }
+        </div>
+    }
+}
+
+@code {
+    [Parameter] public int FormId { get; set; }
+    [Parameter] public int ResponseId { get; set; }
+
+    private Form? form;
+    private Dictionary<string, object>? response;
+    private string? responderName;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var user = await CookieHelper.LoginStatus();
+            if (string.IsNullOrEmpty(user))
+            {
+                var ret = Uri.EscapeDataString(Navigation.ToBaseRelativePath(Navigation.Uri));
+                Navigation.NavigateTo($"login?returnUrl={ret}", true);
+                return;
+            }
+
+            form = await Http.GetFromJsonAsync<Form>($"api/forms/{FormId}");
+            response = await Http.GetFromJsonAsync<Dictionary<string, object>>($"api/forms/{FormId}/responses/{ResponseId}");
+            if (response.TryGetValue("ResponderName", out var respName))
+            {
+                responderName = respName?.ToString();
+            }
+            StateHasChanged();
+        }
+    }
+
+    RenderFragment DisplayValue(FormField field) => builder =>
+    {
+        if (response == null) return;
+        response.TryGetValue(field.Key, out var valObj);
+        var val = valObj?.ToString() ?? string.Empty;
+        if (field.FieldType == "file")
+        {
+            if (string.IsNullOrWhiteSpace(val))
+            {
+                builder.AddContent(0, "No file");
+                return;
+            }
+            if (val.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+            {
+                builder.AddMarkupContent(1, $"<iframe src='/{val}' width='100%' height='200px' style='border:none;'></iframe>");
+            }
+            else if (IsImage(val))
+            {
+                builder.AddMarkupContent(2, $"<img src='/{val}' class='img-thumbnail' style='max-height:120px;' />");
+            }
+            else
+            {
+                builder.OpenElement(3, "a");
+                builder.AddAttribute(4, "href", $"/{val}");
+                builder.AddAttribute(5, "target", "_blank");
+                builder.AddContent(6, "Open File");
+                builder.CloseElement();
+            }
+        }
+        else if (field.FieldType == "checkbox")
+        {
+            if (!string.IsNullOrWhiteSpace(val))
+            {
+                try
+                {
+                    var list = JsonSerializer.Deserialize<List<string>>(val) ?? new();
+                    builder.AddContent(7, string.Join(", ", list));
+                }
+                catch
+                {
+                    builder.AddContent(8, val);
+                }
+            }
+        }
+        else
+        {
+            builder.AddContent(9, val);
+        }
+    };
+
+    bool IsImage(string path)
+    {
+        var lower = path.ToLowerInvariant();
+        return lower.EndsWith(".jpg") || lower.EndsWith(".jpeg") ||
+               lower.EndsWith(".png") || lower.EndsWith(".gif") ||
+               lower.EndsWith(".bmp") || lower.EndsWith(".webp");
+    }
+}

--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -1,14 +1,17 @@
 @page "/"
 @inject NavigationManager Navigation
 @inject CookieHelper CookieHelper
+@inject HttpClient Http
 
 <h3 class="mb-3">Welcome</h3>
+<p class="text-muted">Total forms created: @totalForms</p>
 <div class="d-flex gap-3">
     <a href="/forms/new" class="btn btn-primary">Create Form</a>
     <a href="/myforms" class="btn btn-secondary">My Forms</a>
 </div>
 
 @code {
+    private int totalForms;
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
@@ -18,6 +21,12 @@
             {
                 var ret = Uri.EscapeDataString(Navigation.ToBaseRelativePath(Navigation.Uri));
                 Navigation.NavigateTo($"login?returnUrl={ret}", true);
+            }
+            else
+            {
+                var forms = await Http.GetFromJsonAsync<List<Form>>("api/forms");
+                totalForms = forms?.Count(f => f.IsActive) ?? 0;
+                StateHasChanged();
             }
         }
     }

--- a/Client/Services/EmailServiceProxy.cs
+++ b/Client/Services/EmailServiceProxy.cs
@@ -19,5 +19,11 @@ namespace DynamicFormsApp.Client.Services
         {
             await _httpClient.PostAsJsonAsync("api/email/bug/", email);
         }
+
+        public async Task SendFormResponseNotification(string toEmail, string formName, int formId)
+        {
+            var payload = new { toEmail, formName, formId };
+            await _httpClient.PostAsJsonAsync("api/email/formresponse", payload);
+        }
     }
 }

--- a/NdaProcesses.Shared/Models/CreateFormDto.cs
+++ b/NdaProcesses.Shared/Models/CreateFormDto.cs
@@ -11,7 +11,11 @@ namespace DynamicFormsApp.Server.Services
     public class CreateFormDto
     {
         public string Name { get; set; }
+        public string? Description { get; set; }
         public List<FormField> Fields { get; set; }
         public bool RequireLogin { get; set; } = true;
+        public bool NotifyOnResponse { get; set; } = false;
+        public string? NotificationEmail { get; set; }
+        public bool IsActive { get; set; } = true;
     }
 }

--- a/NdaProcesses.Shared/Models/Form.cs
+++ b/NdaProcesses.Shared/Models/Form.cs
@@ -12,8 +12,12 @@ namespace DynamicFormsApp.Shared.Models
     {
         public int Id { get; set; }
         public string Name { get; set; }
+        public string? Description { get; set; }
         public string CreatedBy { get; set; }
         public bool RequireLogin { get; set; } = true;
+        public bool NotifyOnResponse { get; set; } = false;
+        public string? NotificationEmail { get; set; }
+        public bool IsActive { get; set; } = true;
         public List<FormField>? Fields { get; set; }
     }
 }

--- a/NdaProcesses.Shared/Services/IEmailService.cs
+++ b/NdaProcesses.Shared/Services/IEmailService.cs
@@ -6,5 +6,6 @@ namespace DynamicFormsApp.Shared.Services
     public interface IEmailService
     {
         Task SendBugReportEmail(EmailModel email);
+        Task SendFormResponseNotification(string toEmail, string formName, int formId);
     }
 }

--- a/Server/Components/App.razor
+++ b/Server/Components/App.razor
@@ -25,8 +25,8 @@
     <script>navigator.serviceWorker.register('service-worker.js');</script>
     <script src="js/cookieHelper.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-    <script src="js/sortable-wrapper.js"></script>
-    <script src="js/dragdrop-wrapper.js"></script>
+    <script type="module" src="js/sortable-wrapper.js"></script>
+    <script type="module" src="js/dragdrop-wrapper.js"></script>
     <script src="js/chartInterop.js"></script>
     <script src="js/exportHelper.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/Server/Controllers/EmailController.cs
+++ b/Server/Controllers/EmailController.cs
@@ -22,5 +22,19 @@ namespace DynamicFormsApp.Server.Controllers
             await _emailService.SendBugReportEmail(email);
             return Ok();
         }
+
+        [HttpPost("formresponse")]
+        public async Task<IActionResult> SendFormResponseEmail([FromBody] FormResponseNotification model)
+        {
+            await _emailService.SendFormResponseNotification(model.toEmail, model.formName, model.formId);
+            return Ok();
+        }
+
+        public class FormResponseNotification
+        {
+            public string toEmail { get; set; }
+            public string formName { get; set; }
+            public int formId { get; set; }
+        }
     }
 }

--- a/Server/Controllers/FormsController.cs
+++ b/Server/Controllers/FormsController.cs
@@ -1,5 +1,6 @@
 ﻿using DynamicFormsApp.Server.Services;
 using DynamicFormsApp.Shared.Models;
+using DynamicFormsApp.Shared.Services;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -11,9 +12,14 @@ namespace DynamicFormsApp.Server.Controllers
     public class FormsController : ControllerBase
     {
         private readonly DynamicFormService _svc;
-        public FormsController(DynamicFormService svc)
+        private readonly IUserService _userSvc;
+        private readonly IEmailService _emailSvc;
+
+        public FormsController(DynamicFormService svc, IUserService userSvc, IEmailService emailSvc)
         {
             _svc = svc;
+            _userSvc = userSvc;
+            _emailSvc = emailSvc;
         }
 
         // POST /api/forms
@@ -25,7 +31,7 @@ namespace DynamicFormsApp.Server.Controllers
                 return Unauthorized();
             }
 
-            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Fields, user, dto.RequireLogin);
+            var newFormId = await _svc.CreateFormAsync(dto.Name, dto.Description, dto.Fields, user, dto.RequireLogin, dto.NotifyOnResponse, dto.NotificationEmail, dto.IsActive);
             return Ok(new { FormId = newFormId });
         }
 
@@ -36,6 +42,13 @@ namespace DynamicFormsApp.Server.Controllers
         {
             var rows = await _svc.GetResponsesAsync(id);
             return Ok(rows);
+        }
+
+        [HttpGet("{id}/responses/{responseId}")]
+        public async Task<ActionResult<Dictionary<string, object>>> GetResponse(int id, int responseId)
+        {
+            var row = await _svc.GetResponseAsync(id, responseId);
+            return Ok(row);
         }
 
 
@@ -54,6 +67,14 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok(all);
         }
 
+        [HttpGet("search")]
+        public async Task<ActionResult<IEnumerable<Form>>> Search([FromQuery] bool includePrivate = false)
+        {
+            var loggedIn = Request.Cookies.TryGetValue("userName", out var user) && !string.IsNullOrEmpty(user);
+            var results = await _svc.SearchFormsAsync(loggedIn && includePrivate);
+            return Ok(results);
+        }
+
         [HttpGet("mine")]
         public async Task<ActionResult<IEnumerable<Form>>> GetMine()
         {
@@ -66,6 +87,19 @@ namespace DynamicFormsApp.Server.Controllers
             return Ok(mine);
         }
 
+        // DELETE /api/forms/{id}
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            if (!Request.Cookies.TryGetValue("userName", out var user) || string.IsNullOrEmpty(user))
+            {
+                return Unauthorized();
+            }
+
+            await _svc.DeactivateFormAsync(id, user);
+            return NoContent();
+        }
+
         // POST /api/forms/{id}/responses
         [HttpPost("{id}/responses")]
 
@@ -73,8 +107,34 @@ namespace DynamicFormsApp.Server.Controllers
         {
             try
             {
+                string? responder = null;
+                var form = await _svc.GetFormAsync(id);
+                if (form.RequireLogin && Request.Cookies.TryGetValue("userName", out var userId) && !string.IsNullOrEmpty(userId))
+                {
+                    var userData = await _userSvc.GetUserData(userId);
+                    responder = userData?.DisplayName ?? userId;
+                }
 
-                await _svc.StoreResponseAsync(id, values);
+                form = await _svc.StoreResponseAsync(id, values, responder);
+
+                if (form.NotifyOnResponse)
+                {
+                    string? to = form.NotificationEmail;
+                    if (string.IsNullOrWhiteSpace(to))
+                    {
+                        var user = await _userSvc.GetUserData(form.CreatedBy);
+                        if (user != null && !string.IsNullOrEmpty(user.Email))
+                        {
+                            to = user.Email;
+                        }
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(to))
+                    {
+                        await _emailSvc.SendFormResponseNotification(to, form.Name, form.Id);
+                    }
+                }
+
                 return NoContent();
             }
             catch (Exception ex)

--- a/Server/Services/CreateFormDto.cs
+++ b/Server/Services/CreateFormDto.cs
@@ -6,8 +6,12 @@ namespace DynamicFormsApp.Server.Services
     public class CreateFormDto
     {
         public string Name { get; set; }
+        public string? Description { get; set; }
         public List<FormField> Fields { get; set; }
         public bool RequireLogin { get; set; } = true;
+        public bool NotifyOnResponse { get; set; } = false;
+        public string? NotificationEmail { get; set; }
+        public bool IsActive { get; set; } = true;
         public string? CreatedBy { get; set; }
     }
 }

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -24,24 +24,48 @@ namespace DynamicFormsApp.Server.Services
         private string SanitizeKey(string raw) =>
             Regex.Replace(raw, @"[^\w]", "_");
 
-        public async Task<int> CreateFormAsync(string formName, List<FormField> fields, string createdBy, bool requireLogin)
+        private string GetUniqueKey(string rawKey, HashSet<string> existing)
+        {
+            var baseKey = SanitizeKey(rawKey);
+            var unique = baseKey;
+            int suffix = 1;
+            while (existing.Contains(unique))
+            {
+                unique = $"{baseKey}_{suffix}";
+                suffix++;
+            }
+            existing.Add(unique);
+            return unique;
+        }
+
+
+        public async Task<int> CreateFormAsync(string formName, string? description, List<FormField> fields, string createdBy, bool requireLogin, bool notifyOnResponse, string? notificationEmail, bool isActive)
         {
             var form = new Form
             {
                 Name = formName,
+                Description = description,
                 CreatedBy = createdBy,
                 RequireLogin = requireLogin,
-                Fields = fields.Select(f => new FormField
-                {
-                    Key = SanitizeKey(f.Key),
-                    Label = f.Label,
-                    FieldType = f.FieldType,
-                    IsRequired = f.IsRequired,
-                    OptionsJson = f.OptionsJson,
-                    Row = f.Row,
-                    Column = f.Column
-                }).ToList()
+                NotifyOnResponse = notifyOnResponse,
+                NotificationEmail = notificationEmail,
+                IsActive = isActive,
+                Fields = new List<FormField>()
             };
+            var keySet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var fld in fields)
+            {
+                form.Fields.Add(new FormField
+                {
+                    Key = GetUniqueKey(fld.Key, keySet),
+                    Label = fld.Label,
+                    FieldType = fld.FieldType,
+                    IsRequired = fld.IsRequired,
+                    OptionsJson = fld.OptionsJson,
+                    Row = fld.Row,
+                    Column = fld.Column
+                });
+            }
             _db.Forms.Add(form);
             await _db.SaveChangesAsync();
 
@@ -51,6 +75,10 @@ namespace DynamicFormsApp.Server.Services
                 $"CREATE TABLE [{tableName}] (" +
                 "ResponseId INT IDENTITY(1,1) PRIMARY KEY, " +
                 "CreatedAt DATETIME2 NOT NULL");
+            if (requireLogin)
+            {
+                sb.Append(", [ResponderName] NVARCHAR(255) NULL");
+            }
 
             foreach (var fld in form.Fields)
             {
@@ -70,7 +98,7 @@ namespace DynamicFormsApp.Server.Services
                 ?? throw new InvalidOperationException("Form not found");
         }
 
-        public async Task StoreResponseAsync(int formId, Dictionary<string, object> values)
+        public async Task<Form> StoreResponseAsync(int formId, Dictionary<string, object> values, string? responderName = null)
         {
             var form = await _db.Forms.FindAsync(formId)
                        ?? throw new InvalidOperationException("Form not found");
@@ -81,6 +109,11 @@ namespace DynamicFormsApp.Server.Services
             var paramNames = string.Join(", ",
                 values.Keys.Select((k, i) => $"@p{i}")
                            .Concat(new[] { "@p_created" }));
+            if (form.RequireLogin)
+            {
+                cols += ", ResponderName";
+                paramNames += ", @p_responder";
+            }
 
             var sql = $"INSERT INTO [{tableName}] ({cols}) VALUES ({paramNames});";
 
@@ -115,21 +148,54 @@ namespace DynamicFormsApp.Server.Services
             }
 
             sqlParams.Add(new SqlParameter("@p_created", DateTime.UtcNow));
+            if (form.RequireLogin)
+            {
+                sqlParams.Add(new SqlParameter("@p_responder", (object?)responderName ?? DBNull.Value));
+            }
             await _db.Database.ExecuteSqlRawAsync(sql, sqlParams.ToArray());
+
+            return form;
+        }
+
+        public async Task DeactivateFormAsync(int formId, string user)
+        {
+            var form = await _db.Forms.FirstOrDefaultAsync(f => f.Id == formId && f.CreatedBy == user);
+            if (form == null)
+            {
+                throw new InvalidOperationException("Form not found");
+            }
+
+            form.IsActive = false;
+            await _db.SaveChangesAsync();
         }
 
         public async Task<List<Form>> GetAllFormsAsync()
         {
             return await _db.Forms
                 .Include(f => f.Fields)
+                .Where(f => f.IsActive)
                 .ToListAsync();
+        }
+
+        public async Task<List<Form>> SearchFormsAsync(bool includePrivate)
+        {
+            var query = _db.Forms
+                .Include(f => f.Fields)
+                .Where(f => f.IsActive);
+
+            if (!includePrivate)
+            {
+                query = query.Where(f => !f.RequireLogin);
+            }
+
+            return await query.ToListAsync();
         }
 
         public async Task<List<Form>> GetFormsByUserAsync(string user)
         {
             return await _db.Forms
                 .Include(f => f.Fields)
-                .Where(f => f.CreatedBy == user)
+                .Where(f => f.CreatedBy == user && f.IsActive)
                 .ToListAsync();
         }
 
@@ -163,6 +229,40 @@ namespace DynamicFormsApp.Server.Services
                 results.Add(row);
             }
             return results;
+        }
+
+        public async Task<Dictionary<string, object>> GetResponseAsync(int formId, int responseId)
+        {
+            var form = await _db.Forms.FindAsync(formId)
+                       ?? throw new InvalidOperationException("Form not found");
+            var rawName = SanitizeKey(form.Name);
+            var tableName = $"Form_{formId}_{rawName}";
+
+            using var conn = _db.Database.GetDbConnection();
+            if (conn.State != System.Data.ConnectionState.Open)
+                await conn.OpenAsync();
+
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = $"SELECT * FROM [{tableName}] WHERE ResponseId=@id;";
+            var param = cmd.CreateParameter();
+            param.ParameterName = "@id";
+            param.Value = responseId;
+            cmd.Parameters.Add(param);
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            if (!await reader.ReadAsync())
+            {
+                throw new InvalidOperationException("Response not found");
+            }
+
+            var row = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < reader.FieldCount; i++)
+            {
+                var name = reader.GetName(i);
+                var val = await reader.IsDBNullAsync(i) ? null : reader.GetValue(i);
+                row[name] = val!;
+            }
+            return row;
         }
 
         private string MapToSqlType(string fieldType) => fieldType switch

--- a/Server/Services/EmailService.cs
+++ b/Server/Services/EmailService.cs
@@ -49,5 +49,28 @@ namespace DynamicFormsApp.Server.Services
             };
             await client.SendMailAsync(mail);
         }
+
+        public async Task SendFormResponseNotification(string toEmail, string formName, int formId)
+        {
+            var baseUrl = _configuration["AppBaseUrl"]?.TrimEnd('/') ?? string.Empty;
+            var responsesLink = $"{baseUrl}/forms/{formId}/responses";
+
+            var mail = new MailMessage
+            {
+                From = new MailAddress("NDABugReport@ntnanderson.com"),
+                Subject = $"Your form '{formName}' received a new response",
+                Body = $"A new response has been submitted for your form '<b>{formName}</b>'.<br/>" +
+                       $"<a href='{responsesLink}'>View responses</a>.",
+                IsBodyHtml = true
+            };
+
+            mail.To.Add(toEmail);
+
+            using var client = new SmtpClient(_configuration["Email:IP"])
+            {
+                Port = int.Parse(_configuration["Email:Port"]!)
+            };
+            await client.SendMailAsync(mail);
+        }
     }
 }

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -14,4 +14,5 @@
     }
   },
   "AllowedHosts": "*"
+  ,"AppBaseUrl": "https://example.com"
 }

--- a/Server/wwwroot/css/form-builder.css
+++ b/Server/wwwroot/css/form-builder.css
@@ -3,9 +3,12 @@
     cursor: grab;
     border: 1px dashed #ced4da;
     background-color: #f8f9fa;
-    padding: 0.75rem;
+    padding: 0.5rem 0.75rem;
     transition: all 0.2s ease;
     user-select: none;
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 calc(50% - 0.5rem);
 }
 
     .draggable-field:active {
@@ -38,6 +41,22 @@
     .drag-handle:active {
         cursor: grabbing;
     }
+
+/* ↕️ Row move handle */
+.row-handle {
+    cursor: grab;
+    position: absolute;
+    left: -1rem;
+    top: 0.25rem;
+}
+
+    .row-handle:active {
+        cursor: grabbing;
+    }
+
+.row-wrapper {
+    position: relative;
+}
 /* ➕ Row drop zones */
 .row-dropzone {
     height: 20px;
@@ -78,5 +97,8 @@ body[data-bs-theme="dark"] .row-dropzone {
 }
 body[data-bs-theme="dark"] .row-dropzone::after {
     background: #343a40;
+    color: #adb5bd;
+}
+body[data-bs-theme="dark"] .row-handle {
     color: #adb5bd;
 }

--- a/Server/wwwroot/js/dragdrop-wrapper.js
+++ b/Server/wwwroot/js/dragdrop-wrapper.js
@@ -1,4 +1,4 @@
-window.initFieldDragDrop = (canvasSelector, dotnetHelper) => {
+export function initFieldDragDrop(canvasSelector, dotnetHelper) {
     const canvas = document.querySelector(canvasSelector);
     if (!canvas) return;
     if (canvas.dataset.dragInit === 'true') return;
@@ -46,7 +46,10 @@ window.initFieldDragDrop = (canvasSelector, dotnetHelper) => {
         }
         dotnetHelper.invokeMethodAsync('AddFieldFromDrop', type, rowIndex, colIndex);
     });
-}; 
+}
 
-// Backwards compatibility
-window.initDragDrop = window.initFieldDragDrop;
+export const initDragDrop = initFieldDragDrop;
+
+// Expose globally for non-module usage
+window.initFieldDragDrop = initFieldDragDrop;
+window.initDragDrop = initDragDrop;

--- a/Server/wwwroot/js/sortable-wrapper.js
+++ b/Server/wwwroot/js/sortable-wrapper.js
@@ -1,4 +1,4 @@
-window.initSortable = (selector, dotnetHelper) => {
+export function initSortable(selector, dotnetHelper) {
     const container = document.querySelector(selector);
     if (!container) return;
 
@@ -16,4 +16,33 @@ window.initSortable = (selector, dotnetHelper) => {
             }
         });
     });
-};
+}
+
+export function initListSortable(selector, dotnetHelper) {
+    const container = document.querySelector(selector);
+    if (!container || container.dataset.sortableInit === 'true') return;
+    container.dataset.sortableInit = 'true';
+    new Sortable(container, {
+        animation: 150,
+        handle: '.move-handle',
+        onEnd: evt => dotnetHelper.invokeMethodAsync('OnFieldReorder', evt.oldIndex, evt.newIndex)
+    });
+}
+
+export function initRowSortable(selector, dotnetHelper) {
+    const container = document.querySelector(selector);
+    if (!container || container.dataset.rowSortableInit === 'true') return;
+    container.dataset.rowSortableInit = 'true';
+    new Sortable(container, {
+        animation: 150,
+        handle: '.row-handle',
+        draggable: '.row-wrapper',
+        onEnd: evt => dotnetHelper.invokeMethodAsync('OnRowReorder', evt.oldIndex, evt.newIndex)
+    });
+}
+
+// Also expose globally for non-module usage
+window.initSortable = initSortable;
+window.initListSortable = initListSortable;
+window.initRowSortable = initRowSortable;
+


### PR DESCRIPTION
## Summary
- let form designer rows be draggable with new handles
- JS helper initializes row sortable behaviour
- styles for row handle and wrapper
- reinitialize row sorting after changes
- load drag-and-drop scripts as ES modules to avoid missing functions
- fix compile issue by adding System.Linq using on Search Forms page

## Testing
- ❌ `dotnet test DynamicFormsApp.sln` (failed to run: command not found)


------
https://chatgpt.com/codex/tasks/task_e_685445bda4bc83298199dc85af821ea4